### PR TITLE
Support moving serialization files to new path

### DIFF
--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -13,7 +13,7 @@ function validate_serialization(sys::System)
         sys_ext["data"] = 5
         ext_test_bus_name = ""
         try
-            IS.prepare_for_serialization!(sys.data, path)
+            IS.prepare_for_serialization!(sys.data, path; force = true)
             bus = collect(get_components(PSY.Bus, sys))[1]
             ext_test_bus_name = PSY.get_name(bus)
             ext = PSY.get_ext(bus)
@@ -38,8 +38,6 @@ end
 @testset "Test JSON serialization of CDM data" begin
     sys = create_rts_system()
     @test validate_serialization(sys)
-    text = JSON2.write(sys)
-    @test length(text) > 0
 end
 
 @testset "Test JSON serialization of matpower data" begin

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -249,16 +249,12 @@ end
         Bus(11, "11", BusTypes.PQ, 1, 1, (min = 0.9, max = 1.1), 123, nothing, nothing),
     )
     path = joinpath(mktempdir(), "test_validation.json")
-    io = open(path, "w")
-    PSY.to_json(sys, path)
     try
-        to_json(io, sys)
+        PSY.to_json(sys, path)
     catch
-        close(io)
         rm(path)
         rethrow()
     end
-    close(io)
 
     try
         sys2 = PSY.System(path)


### PR DESCRIPTION
Note that I deviated from the workflow discussed today.  The JSON filename is the basis of the interface, not the directory.

Fixes issue #472 