### PR TITLE
Update Dynamic Structs

### DIFF
--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2333,10 +2333,9 @@
         "docstring": "Parameters of a AVR that returns a fixed voltage to the rotor winding",
         "fields": [
             {
-                "name": "V_ref",
-                "comment": "Reference Voltage Set-point",
+                "name": "Vf",
+                "comment": "Fixed voltage field applied to the rotor winding",
                 "null_value": 0,
-                "default": "1.0",
                 "data_type": "Float64",
                 "valid_range": {
                     "min": 0,

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2333,9 +2333,10 @@
         "docstring": "Parameters of a AVR that returns a fixed voltage to the rotor winding",
         "fields": [
             {
-                "name": "Emf",
-                "comment": "Fixed voltage to the rotor winding",
+                "name": "V_ref",
+                "comment": "Reference Voltage Set-point",
                 "null_value": 0,
+                "default": "1.0",
                 "data_type": "Float64",
                 "valid_range": {
                     "min": 0,
@@ -2378,6 +2379,17 @@
                 "name": "Kv",
                 "comment": "Proportional Gain",
                 "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "V_ref",
+                "comment": "Reference Voltage Set-point",
+                "null_value": 0,
+                "default": "1.0",
                 "data_type": "Float64",
                 "valid_range": {
                     "min": 0,
@@ -2526,6 +2538,17 @@
                 }
             },
             {
+                "name": "V_ref",
+                "comment": "Reference Voltage Set-point",
+                "null_value": 0,
+                "default": "1.0",
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
                 "name": "ext",
                 "data_type": "Dict{String, Any}",
                 "null_value": "Dict{String, Any}()",
@@ -2667,6 +2690,17 @@
                 }
             },
             {
+                "name": "V_ref",
+                "comment": "Reference Voltage Set-point",
+                "null_value": 0,
+                "default": "1.0",
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
                 "name": "ext",
                 "data_type": "Dict{String, Any}",
                 "null_value": "Dict{String, Any}()",
@@ -2720,16 +2754,6 @@
             {
                 "name": "eq_p",
                 "comment": "Fixed EMF behind the impedance",
-                "null_value": 0,
-                "data_type": "Float64",
-                "valid_range": {
-                    "min": 0,
-                    "max": null
-                }
-            },
-            {
-                "name": "MVABase",
-                "comment": "Nominal Capacity in MVA",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
@@ -2871,16 +2895,6 @@
             {
                 "name": "Tq0_pp",
                 "comment": "Time constant of sub-transient q-axis voltage",
-                "null_value": 0,
-                "data_type": "Float64",
-                "valid_range": {
-                    "min": 0,
-                    "max": null
-                }
-            },
-            {
-                "name": "MVABase",
-                "comment": "Nominal Capacity in MVA",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
@@ -3033,16 +3047,6 @@
                 "name": "L_1q",
                 "comment": "Inductance of the q-axis rotor damping circuit, in per unit",
                 "null_value": 1.0,
-                "data_type": "Float64",
-                "valid_range": {
-                    "min": 0,
-                    "max": null
-                }
-            },
-            {
-                "name": "MVABase",
-                "comment": "Nominal Capacity in MVA",
-                "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
                     "min": 0,
@@ -3213,16 +3217,6 @@
                 }
             },
             {
-                "name": "MVABase",
-                "comment": "Nominal Capacity in MVA",
-                "null_value": 0,
-                "data_type": "Float64",
-                "valid_range": {
-                    "min": 0,
-                    "max": null
-                }
-            },
-            {
                 "name": "ext",
                 "data_type": "Dict{String, Any}",
                 "null_value": "Dict{String, Any}()",
@@ -3328,16 +3322,6 @@
             {
                 "name": "Tq0_p",
                 "comment": "Time constant of transient q-axis voltage",
-                "null_value": 0,
-                "data_type": "Float64",
-                "valid_range": {
-                    "min": 0,
-                    "max": null
-                }
-            },
-            {
-                "name": "MVABase",
-                "comment": "Nominal Capacity in MVA",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
@@ -3479,16 +3463,6 @@
             {
                 "name": "Tq0_pp",
                 "comment": "Time constant of sub-transient q-axis voltage",
-                "null_value": 0,
-                "data_type": "Float64",
-                "valid_range": {
-                    "min": 0,
-                    "max": null
-                }
-            },
-            {
-                "name": "MVABase",
-                "comment": "Nominal Capacity in MVA",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
@@ -3641,16 +3615,6 @@
                 "name": "L_1q",
                 "comment": "Inductance of the q-axis rotor damping circuit, in per unit",
                 "null_value": 2.0,
-                "data_type": "Float64",
-                "valid_range": {
-                    "min": 0,
-                    "max": null
-                }
-            },
-            {
-                "name": "MVABase",
-                "comment": "Nominal Capacity in MVA",
-                "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
                     "min": 0,
@@ -3813,16 +3777,6 @@
             {
                 "name": "T_AA",
                 "comment": "Time constant of d-axis additional leakage",
-                "null_value": 0,
-                "data_type": "Float64",
-                "valid_range": {
-                    "min": 0,
-                    "max": null
-                }
-            },
-            {
-                "name": "MVABase",
-                "comment": "Nominal Capacity in MVA",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
@@ -4238,6 +4192,17 @@
                 }
             },
             {
+                "name": "P_ref",
+                "comment": "Reference Power Set-point",
+                "null_value": 0,
+                "default": "1.0",
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
                 "name": "ext",
                 "data_type": "Dict{String, Any}",
                 "null_value": "Dict{String, Any}()",
@@ -4349,6 +4314,17 @@
                 }
             },
             {
+                "name": "P_ref",
+                "comment": "Reference Power Set-point",
+                "null_value": 0,
+                "default": "1.0",
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
                 "name": "ext",
                 "data_type": "Dict{String, Any}",
                 "null_value": "Dict{String, Any}()",
@@ -4423,6 +4399,17 @@
                 "name": "τ_max",
                 "comment": "Max Power into the Governor",
                 "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "P_ref",
+                "comment": "Reference Power Set-point",
+                "null_value": 0,
+                "default": "1.0",
                 "data_type": "Float64",
                 "valid_range": {
                     "min": 0,
@@ -4762,9 +4749,10 @@
                 }
             },
             {
-                "name": "ωb",
-                "comment": "rated angular frequency",
+                "name": "P_ref",
+                "comment": "Reference Power Set-point",
                 "null_value": 0,
+                "default": "1.0",
                 "data_type": "Float64",
                 "valid_range": {
                     "min": 0,
@@ -4810,6 +4798,17 @@
                 "name": "ωf",
                 "comment": "filter frequency cutoff",
                 "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "V_ref",
+                "comment": "Reference Voltage Set-point",
+                "null_value": 0,
+                "default": "1.0",
                 "data_type": "Float64",
                 "valid_range": {
                     "min": 0,

--- a/src/models/generated/AVRFixed.jl
+++ b/src/models/generated/AVRFixed.jl
@@ -3,7 +3,7 @@ This file is auto-generated. Do not edit.
 =#
 """
     mutable struct AVRFixed <: AVR
-        Emf::Float64
+        V_ref::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -13,15 +13,15 @@ This file is auto-generated. Do not edit.
 Parameters of a AVR that returns a fixed voltage to the rotor winding
 
 # Arguments
-- `Emf::Float64`: Fixed voltage to the rotor winding, validation range: (0, nothing)
+- `V_ref::Float64`: Reference Voltage Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: Fixed AVR has no states
 - `n_states::Int64`: Fixed AVR has no states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct AVRFixed <: AVR
-    "Fixed voltage to the rotor winding"
-    Emf::Float64
+    "Reference Voltage Set-point"
+    V_ref::Float64
     ext::Dict{String, Any}
     "Fixed AVR has no states"
     states::Vector{Symbol}
@@ -31,24 +31,24 @@ mutable struct AVRFixed <: AVR
     internal::InfrastructureSystemsInternal
 end
 
-function AVRFixed(Emf, ext=Dict{String, Any}(), )
-    AVRFixed(Emf, ext, Vector{Symbol}(), 0, InfrastructureSystemsInternal(), )
+function AVRFixed(V_ref=1.0, ext=Dict{String, Any}(), )
+    AVRFixed(V_ref, ext, Vector{Symbol}(), 0, InfrastructureSystemsInternal(), )
 end
 
-function AVRFixed(; Emf, ext=Dict{String, Any}(), )
-    AVRFixed(Emf, ext, )
+function AVRFixed(; V_ref=1.0, ext=Dict{String, Any}(), )
+    AVRFixed(V_ref, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
 function AVRFixed(::Nothing)
     AVRFixed(;
-        Emf=0,
+        V_ref=0,
         ext=Dict{String, Any}(),
     )
 end
 
-"""Get AVRFixed Emf."""
-get_Emf(value::AVRFixed) = value.Emf
+"""Get AVRFixed V_ref."""
+get_V_ref(value::AVRFixed) = value.V_ref
 """Get AVRFixed ext."""
 get_ext(value::AVRFixed) = value.ext
 """Get AVRFixed states."""
@@ -58,8 +58,8 @@ get_n_states(value::AVRFixed) = value.n_states
 """Get AVRFixed internal."""
 get_internal(value::AVRFixed) = value.internal
 
-"""Set AVRFixed Emf."""
-set_Emf!(value::AVRFixed, val::Float64) = value.Emf = val
+"""Set AVRFixed V_ref."""
+set_V_ref!(value::AVRFixed, val::Float64) = value.V_ref = val
 """Set AVRFixed ext."""
 set_ext!(value::AVRFixed, val::Dict{String, Any}) = value.ext = val
 """Set AVRFixed states."""

--- a/src/models/generated/AVRFixed.jl
+++ b/src/models/generated/AVRFixed.jl
@@ -3,7 +3,7 @@ This file is auto-generated. Do not edit.
 =#
 """
     mutable struct AVRFixed <: AVR
-        V_ref::Float64
+        Vf::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -13,15 +13,15 @@ This file is auto-generated. Do not edit.
 Parameters of a AVR that returns a fixed voltage to the rotor winding
 
 # Arguments
-- `V_ref::Float64`: Reference Voltage Set-point, validation range: (0, nothing)
+- `Vf::Float64`: Fixed voltage field applied to the rotor winding, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: Fixed AVR has no states
 - `n_states::Int64`: Fixed AVR has no states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct AVRFixed <: AVR
-    "Reference Voltage Set-point"
-    V_ref::Float64
+    "Fixed voltage field applied to the rotor winding"
+    Vf::Float64
     ext::Dict{String, Any}
     "Fixed AVR has no states"
     states::Vector{Symbol}
@@ -31,24 +31,24 @@ mutable struct AVRFixed <: AVR
     internal::InfrastructureSystemsInternal
 end
 
-function AVRFixed(V_ref=1.0, ext=Dict{String, Any}(), )
-    AVRFixed(V_ref, ext, Vector{Symbol}(), 0, InfrastructureSystemsInternal(), )
+function AVRFixed(Vf, ext=Dict{String, Any}(), )
+    AVRFixed(Vf, ext, Vector{Symbol}(), 0, InfrastructureSystemsInternal(), )
 end
 
-function AVRFixed(; V_ref=1.0, ext=Dict{String, Any}(), )
-    AVRFixed(V_ref, ext, )
+function AVRFixed(; Vf, ext=Dict{String, Any}(), )
+    AVRFixed(Vf, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
 function AVRFixed(::Nothing)
     AVRFixed(;
-        V_ref=0,
+        Vf=0,
         ext=Dict{String, Any}(),
     )
 end
 
-"""Get AVRFixed V_ref."""
-get_V_ref(value::AVRFixed) = value.V_ref
+"""Get AVRFixed Vf."""
+get_Vf(value::AVRFixed) = value.Vf
 """Get AVRFixed ext."""
 get_ext(value::AVRFixed) = value.ext
 """Get AVRFixed states."""
@@ -58,8 +58,8 @@ get_n_states(value::AVRFixed) = value.n_states
 """Get AVRFixed internal."""
 get_internal(value::AVRFixed) = value.internal
 
-"""Set AVRFixed V_ref."""
-set_V_ref!(value::AVRFixed, val::Float64) = value.V_ref = val
+"""Set AVRFixed Vf."""
+set_Vf!(value::AVRFixed, val::Float64) = value.Vf = val
 """Set AVRFixed ext."""
 set_ext!(value::AVRFixed, val::Dict{String, Any}) = value.ext = val
 """Set AVRFixed states."""

--- a/src/models/generated/AVRSimple.jl
+++ b/src/models/generated/AVRSimple.jl
@@ -4,6 +4,7 @@ This file is auto-generated. Do not edit.
 """
     mutable struct AVRSimple <: AVR
         Kv::Float64
+        V_ref::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -15,6 +16,7 @@ i.e. an integrator controller on EMF
 
 # Arguments
 - `Kv::Float64`: Proportional Gain, validation range: (0, nothing)
+- `V_ref::Float64`: Reference Voltage Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
 - `n_states::Int64`: Fixed AVR has 1 states
@@ -23,6 +25,8 @@ i.e. an integrator controller on EMF
 mutable struct AVRSimple <: AVR
     "Proportional Gain"
     Kv::Float64
+    "Reference Voltage Set-point"
+    V_ref::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
     "Fixed AVR has 1 states"
@@ -31,24 +35,27 @@ mutable struct AVRSimple <: AVR
     internal::InfrastructureSystemsInternal
 end
 
-function AVRSimple(Kv, ext=Dict{String, Any}(), )
-    AVRSimple(Kv, ext, [:Vf], 1, InfrastructureSystemsInternal(), )
+function AVRSimple(Kv, V_ref=1.0, ext=Dict{String, Any}(), )
+    AVRSimple(Kv, V_ref, ext, [:Vf], 1, InfrastructureSystemsInternal(), )
 end
 
-function AVRSimple(; Kv, ext=Dict{String, Any}(), )
-    AVRSimple(Kv, ext, )
+function AVRSimple(; Kv, V_ref=1.0, ext=Dict{String, Any}(), )
+    AVRSimple(Kv, V_ref, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
 function AVRSimple(::Nothing)
     AVRSimple(;
         Kv=0,
+        V_ref=0,
         ext=Dict{String, Any}(),
     )
 end
 
 """Get AVRSimple Kv."""
 get_Kv(value::AVRSimple) = value.Kv
+"""Get AVRSimple V_ref."""
+get_V_ref(value::AVRSimple) = value.V_ref
 """Get AVRSimple ext."""
 get_ext(value::AVRSimple) = value.ext
 """Get AVRSimple states."""
@@ -60,6 +67,8 @@ get_internal(value::AVRSimple) = value.internal
 
 """Set AVRSimple Kv."""
 set_Kv!(value::AVRSimple, val::Float64) = value.Kv = val
+"""Set AVRSimple V_ref."""
+set_V_ref!(value::AVRSimple, val::Float64) = value.V_ref = val
 """Set AVRSimple ext."""
 set_ext!(value::AVRSimple, val::Dict{String, Any}) = value.ext = val
 """Set AVRSimple states."""

--- a/src/models/generated/AVRTypeI.jl
+++ b/src/models/generated/AVRTypeI.jl
@@ -14,6 +14,7 @@ This file is auto-generated. Do not edit.
         Vr_min::Float64
         Ae::Float64
         Be::Float64
+        V_ref::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -34,6 +35,7 @@ Parameters of an Automatic Voltage Regulator Type I - Resembles IEEE Type DC1
 - `Vr_min::Float64`: Minimum regulator voltage in pu, validation range: (0, nothing)
 - `Ae::Float64`: 1st ceiling coefficient, validation range: (0, nothing)
 - `Be::Float64`: 2nd ceiling coefficient, validation range: (0, nothing)
+- `V_ref::Float64`: Reference Voltage Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
 - `n_states::Int64`
@@ -62,6 +64,8 @@ mutable struct AVRTypeI <: AVR
     Ae::Float64
     "2nd ceiling coefficient"
     Be::Float64
+    "Reference Voltage Set-point"
+    V_ref::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
     n_states::Int64
@@ -69,12 +73,12 @@ mutable struct AVRTypeI <: AVR
     internal::InfrastructureSystemsInternal
 end
 
-function AVRTypeI(Ka, Ke, Kf, Ta, Te, Tf, Tr, Vr_max, Vr_min, Ae, Be, ext=Dict{String, Any}(), )
-    AVRTypeI(Ka, Ke, Kf, Ta, Te, Tf, Tr, Vr_max, Vr_min, Ae, Be, ext, [:Vf, :Vr1, :Vr2, :Vm], 4, InfrastructureSystemsInternal(), )
+function AVRTypeI(Ka, Ke, Kf, Ta, Te, Tf, Tr, Vr_max, Vr_min, Ae, Be, V_ref=1.0, ext=Dict{String, Any}(), )
+    AVRTypeI(Ka, Ke, Kf, Ta, Te, Tf, Tr, Vr_max, Vr_min, Ae, Be, V_ref, ext, [:Vf, :Vr1, :Vr2, :Vm], 4, InfrastructureSystemsInternal(), )
 end
 
-function AVRTypeI(; Ka, Ke, Kf, Ta, Te, Tf, Tr, Vr_max, Vr_min, Ae, Be, ext=Dict{String, Any}(), )
-    AVRTypeI(Ka, Ke, Kf, Ta, Te, Tf, Tr, Vr_max, Vr_min, Ae, Be, ext, )
+function AVRTypeI(; Ka, Ke, Kf, Ta, Te, Tf, Tr, Vr_max, Vr_min, Ae, Be, V_ref=1.0, ext=Dict{String, Any}(), )
+    AVRTypeI(Ka, Ke, Kf, Ta, Te, Tf, Tr, Vr_max, Vr_min, Ae, Be, V_ref, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -91,6 +95,7 @@ function AVRTypeI(::Nothing)
         Vr_min=0,
         Ae=0,
         Be=0,
+        V_ref=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -117,6 +122,8 @@ get_Vr_min(value::AVRTypeI) = value.Vr_min
 get_Ae(value::AVRTypeI) = value.Ae
 """Get AVRTypeI Be."""
 get_Be(value::AVRTypeI) = value.Be
+"""Get AVRTypeI V_ref."""
+get_V_ref(value::AVRTypeI) = value.V_ref
 """Get AVRTypeI ext."""
 get_ext(value::AVRTypeI) = value.ext
 """Get AVRTypeI states."""
@@ -148,6 +155,8 @@ set_Vr_min!(value::AVRTypeI, val::Float64) = value.Vr_min = val
 set_Ae!(value::AVRTypeI, val::Float64) = value.Ae = val
 """Set AVRTypeI Be."""
 set_Be!(value::AVRTypeI, val::Float64) = value.Be = val
+"""Set AVRTypeI V_ref."""
+set_V_ref!(value::AVRTypeI, val::Float64) = value.V_ref = val
 """Set AVRTypeI ext."""
 set_ext!(value::AVRTypeI, val::Dict{String, Any}) = value.ext = val
 """Set AVRTypeI states."""

--- a/src/models/generated/AVRTypeII.jl
+++ b/src/models/generated/AVRTypeII.jl
@@ -14,6 +14,7 @@ This file is auto-generated. Do not edit.
         Vr_min::Float64
         Ae::Float64
         Be::Float64
+        V_ref::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -34,6 +35,7 @@ Parameters of an Automatic Voltage Regulator Type II -  Typical static exciter m
 - `Vr_min::Float64`: Minimum regulator voltage in pu, validation range: (0, nothing)
 - `Ae::Float64`: 1st ceiling coefficient, validation range: (0, nothing)
 - `Be::Float64`: 2nd ceiling coefficient, validation range: (0, nothing)
+- `V_ref::Float64`: Reference Voltage Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
 - `n_states::Int64`
@@ -62,6 +64,8 @@ mutable struct AVRTypeII <: AVR
     Ae::Float64
     "2nd ceiling coefficient"
     Be::Float64
+    "Reference Voltage Set-point"
+    V_ref::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
     n_states::Int64
@@ -69,12 +73,12 @@ mutable struct AVRTypeII <: AVR
     internal::InfrastructureSystemsInternal
 end
 
-function AVRTypeII(K0, T1, T2, T3, T4, Te, Tr, Vr_max, Vr_min, Ae, Be, ext=Dict{String, Any}(), )
-    AVRTypeII(K0, T1, T2, T3, T4, Te, Tr, Vr_max, Vr_min, Ae, Be, ext, [:Vf, :Vr1, :Vr2, :Vm], 4, InfrastructureSystemsInternal(), )
+function AVRTypeII(K0, T1, T2, T3, T4, Te, Tr, Vr_max, Vr_min, Ae, Be, V_ref=1.0, ext=Dict{String, Any}(), )
+    AVRTypeII(K0, T1, T2, T3, T4, Te, Tr, Vr_max, Vr_min, Ae, Be, V_ref, ext, [:Vf, :Vr1, :Vr2, :Vm], 4, InfrastructureSystemsInternal(), )
 end
 
-function AVRTypeII(; K0, T1, T2, T3, T4, Te, Tr, Vr_max, Vr_min, Ae, Be, ext=Dict{String, Any}(), )
-    AVRTypeII(K0, T1, T2, T3, T4, Te, Tr, Vr_max, Vr_min, Ae, Be, ext, )
+function AVRTypeII(; K0, T1, T2, T3, T4, Te, Tr, Vr_max, Vr_min, Ae, Be, V_ref=1.0, ext=Dict{String, Any}(), )
+    AVRTypeII(K0, T1, T2, T3, T4, Te, Tr, Vr_max, Vr_min, Ae, Be, V_ref, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -91,6 +95,7 @@ function AVRTypeII(::Nothing)
         Vr_min=0,
         Ae=0,
         Be=0,
+        V_ref=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -117,6 +122,8 @@ get_Vr_min(value::AVRTypeII) = value.Vr_min
 get_Ae(value::AVRTypeII) = value.Ae
 """Get AVRTypeII Be."""
 get_Be(value::AVRTypeII) = value.Be
+"""Get AVRTypeII V_ref."""
+get_V_ref(value::AVRTypeII) = value.V_ref
 """Get AVRTypeII ext."""
 get_ext(value::AVRTypeII) = value.ext
 """Get AVRTypeII states."""
@@ -148,6 +155,8 @@ set_Vr_min!(value::AVRTypeII, val::Float64) = value.Vr_min = val
 set_Ae!(value::AVRTypeII, val::Float64) = value.Ae = val
 """Set AVRTypeII Be."""
 set_Be!(value::AVRTypeII, val::Float64) = value.Be = val
+"""Set AVRTypeII V_ref."""
+set_V_ref!(value::AVRTypeII, val::Float64) = value.V_ref = val
 """Set AVRTypeII ext."""
 set_ext!(value::AVRTypeII, val::Dict{String, Any}) = value.ext = val
 """Set AVRTypeII states."""

--- a/src/models/generated/AndersonFouadMachine.jl
+++ b/src/models/generated/AndersonFouadMachine.jl
@@ -14,7 +14,6 @@ This file is auto-generated. Do not edit.
         Tq0_p::Float64
         Td0_pp::Float64
         Tq0_pp::Float64
-        MVABase::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -35,7 +34,6 @@ Parameters of 6-states synchronous machine: Anderson-Fouad model
 - `Tq0_p::Float64`: Time constant of transient q-axis voltage, validation range: (0, nothing)
 - `Td0_pp::Float64`: Time constant of sub-transient d-axis voltage, validation range: (0, nothing)
 - `Tq0_pp::Float64`: Time constant of sub-transient q-axis voltage, validation range: (0, nothing)
-- `MVABase::Float64`: Nominal Capacity in MVA, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
 - `n_states::Int64`
@@ -64,8 +62,6 @@ mutable struct AndersonFouadMachine <: Machine
     Td0_pp::Float64
     "Time constant of sub-transient q-axis voltage"
     Tq0_pp::Float64
-    "Nominal Capacity in MVA"
-    MVABase::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
     n_states::Int64
@@ -73,12 +69,12 @@ mutable struct AndersonFouadMachine <: Machine
     internal::InfrastructureSystemsInternal
 end
 
-function AndersonFouadMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, MVABase, ext=Dict{String, Any}(), )
-    AndersonFouadMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, MVABase, ext, [:ψq, :ψd, :eq_p, :ed_p, :eq_pp, :ed_pp], 6, InfrastructureSystemsInternal(), )
+function AndersonFouadMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, ext=Dict{String, Any}(), )
+    AndersonFouadMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, ext, [:ψq, :ψd, :eq_p, :ed_p, :eq_pp, :ed_pp], 6, InfrastructureSystemsInternal(), )
 end
 
-function AndersonFouadMachine(; R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, MVABase, ext=Dict{String, Any}(), )
-    AndersonFouadMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, MVABase, ext, )
+function AndersonFouadMachine(; R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, ext=Dict{String, Any}(), )
+    AndersonFouadMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -95,7 +91,6 @@ function AndersonFouadMachine(::Nothing)
         Tq0_p=0,
         Td0_pp=0,
         Tq0_pp=0,
-        MVABase=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -122,8 +117,6 @@ get_Tq0_p(value::AndersonFouadMachine) = value.Tq0_p
 get_Td0_pp(value::AndersonFouadMachine) = value.Td0_pp
 """Get AndersonFouadMachine Tq0_pp."""
 get_Tq0_pp(value::AndersonFouadMachine) = value.Tq0_pp
-"""Get AndersonFouadMachine MVABase."""
-get_MVABase(value::AndersonFouadMachine) = value.MVABase
 """Get AndersonFouadMachine ext."""
 get_ext(value::AndersonFouadMachine) = value.ext
 """Get AndersonFouadMachine states."""
@@ -155,8 +148,6 @@ set_Tq0_p!(value::AndersonFouadMachine, val::Float64) = value.Tq0_p = val
 set_Td0_pp!(value::AndersonFouadMachine, val::Float64) = value.Td0_pp = val
 """Set AndersonFouadMachine Tq0_pp."""
 set_Tq0_pp!(value::AndersonFouadMachine, val::Float64) = value.Tq0_pp = val
-"""Set AndersonFouadMachine MVABase."""
-set_MVABase!(value::AndersonFouadMachine, val::Float64) = value.MVABase = val
 """Set AndersonFouadMachine ext."""
 set_ext!(value::AndersonFouadMachine, val::Dict{String, Any}) = value.ext = val
 """Set AndersonFouadMachine states."""

--- a/src/models/generated/BaseMachine.jl
+++ b/src/models/generated/BaseMachine.jl
@@ -6,7 +6,6 @@ This file is auto-generated. Do not edit.
         R::Float64
         Xd_p::Float64
         eq_p::Float64
-        MVABase::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -19,7 +18,6 @@ Parameters of an Automatic Voltage Regulator Type II -  Typical static exciter m
 - `R::Float64`: Resistance after EMF in machine per unit, validation range: (0, nothing)
 - `Xd_p::Float64`: Reactance after EMF in machine per unit, validation range: (0, nothing)
 - `eq_p::Float64`: Fixed EMF behind the impedance, validation range: (0, nothing)
-- `MVABase::Float64`: Nominal Capacity in MVA, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
 - `n_states::Int64`
@@ -32,8 +30,6 @@ mutable struct BaseMachine <: Machine
     Xd_p::Float64
     "Fixed EMF behind the impedance"
     eq_p::Float64
-    "Nominal Capacity in MVA"
-    MVABase::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
     n_states::Int64
@@ -41,12 +37,12 @@ mutable struct BaseMachine <: Machine
     internal::InfrastructureSystemsInternal
 end
 
-function BaseMachine(R, Xd_p, eq_p, MVABase, ext=Dict{String, Any}(), )
-    BaseMachine(R, Xd_p, eq_p, MVABase, ext, Vector{Symbol}(), 0, InfrastructureSystemsInternal(), )
+function BaseMachine(R, Xd_p, eq_p, ext=Dict{String, Any}(), )
+    BaseMachine(R, Xd_p, eq_p, ext, Vector{Symbol}(), 0, InfrastructureSystemsInternal(), )
 end
 
-function BaseMachine(; R, Xd_p, eq_p, MVABase, ext=Dict{String, Any}(), )
-    BaseMachine(R, Xd_p, eq_p, MVABase, ext, )
+function BaseMachine(; R, Xd_p, eq_p, ext=Dict{String, Any}(), )
+    BaseMachine(R, Xd_p, eq_p, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -55,7 +51,6 @@ function BaseMachine(::Nothing)
         R=0,
         Xd_p=0,
         eq_p=0,
-        MVABase=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -66,8 +61,6 @@ get_R(value::BaseMachine) = value.R
 get_Xd_p(value::BaseMachine) = value.Xd_p
 """Get BaseMachine eq_p."""
 get_eq_p(value::BaseMachine) = value.eq_p
-"""Get BaseMachine MVABase."""
-get_MVABase(value::BaseMachine) = value.MVABase
 """Get BaseMachine ext."""
 get_ext(value::BaseMachine) = value.ext
 """Get BaseMachine states."""
@@ -83,8 +76,6 @@ set_R!(value::BaseMachine, val::Float64) = value.R = val
 set_Xd_p!(value::BaseMachine, val::Float64) = value.Xd_p = val
 """Set BaseMachine eq_p."""
 set_eq_p!(value::BaseMachine, val::Float64) = value.eq_p = val
-"""Set BaseMachine MVABase."""
-set_MVABase!(value::BaseMachine, val::Float64) = value.MVABase = val
 """Set BaseMachine ext."""
 set_ext!(value::BaseMachine, val::Dict{String, Any}) = value.ext = val
 """Set BaseMachine states."""

--- a/src/models/generated/FullMachine.jl
+++ b/src/models/generated/FullMachine.jl
@@ -15,7 +15,6 @@ This file is auto-generated. Do not edit.
         L_ff::Float64
         L_1d::Float64
         L_1q::Float64
-        MVABase::Float64
         ext::Dict{String, Any}
         inv_d_fluxlink::Array{Float64,2}
         inv_q_fluxlink::Array{Float64,2}
@@ -42,7 +41,6 @@ Parameter of a full order flux stator-rotor model without zero sequence flux in 
 - `L_ff::Float64`: Field rotor winding inductance, in per unit, validation range: (0, nothing)
 - `L_1d::Float64`: Inductance of the d-axis rotor damping circuit, in per unit, validation range: (0, nothing)
 - `L_1q::Float64`: Inductance of the q-axis rotor damping circuit, in per unit, validation range: (0, nothing)
-- `MVABase::Float64`: Nominal Capacity in MVA, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `inv_d_fluxlink::Array{Float64,2}`: Equations 3.127, 3.130, 3.131 From Kundur
 - `inv_q_fluxlink::Array{Float64,2}`: Equations 3.128, 3.132 From Kundur
@@ -75,8 +73,6 @@ mutable struct FullMachine <: Machine
     L_1d::Float64
     "Inductance of the q-axis rotor damping circuit, in per unit"
     L_1q::Float64
-    "Nominal Capacity in MVA"
-    MVABase::Float64
     ext::Dict{String, Any}
     "Equations 3.127, 3.130, 3.131 From Kundur"
     inv_d_fluxlink::Array{Float64,2}
@@ -88,12 +84,12 @@ mutable struct FullMachine <: Machine
     internal::InfrastructureSystemsInternal
 end
 
-function FullMachine(R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, MVABase, ext=Dict{String, Any}(), )
-    FullMachine(R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, MVABase, ext, inv([[-L_d L_ad L_ad]; [-L_ad L_ff L_f1d]; [-L_ad L_f1d L_1d]]), inv([[-L_q L_aq]; [-L_aq L_1q]]), [:ψd, :ψq, :ψf, :ψ1d, :ψ1q], 5, InfrastructureSystemsInternal(), )
+function FullMachine(R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, ext=Dict{String, Any}(), )
+    FullMachine(R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, ext, inv([[-L_d L_ad L_ad]; [-L_ad L_ff L_f1d]; [-L_ad L_f1d L_1d]]), inv([[-L_q L_aq]; [-L_aq L_1q]]), [:ψd, :ψq, :ψf, :ψ1d, :ψ1q], 5, InfrastructureSystemsInternal(), )
 end
 
-function FullMachine(; R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, MVABase, ext=Dict{String, Any}(), )
-    FullMachine(R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, MVABase, ext, )
+function FullMachine(; R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, ext=Dict{String, Any}(), )
+    FullMachine(R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -111,7 +107,6 @@ function FullMachine(::Nothing)
         L_ff=2.0,
         L_1d=1.0,
         L_1q=1.0,
-        MVABase=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -140,8 +135,6 @@ get_L_ff(value::FullMachine) = value.L_ff
 get_L_1d(value::FullMachine) = value.L_1d
 """Get FullMachine L_1q."""
 get_L_1q(value::FullMachine) = value.L_1q
-"""Get FullMachine MVABase."""
-get_MVABase(value::FullMachine) = value.MVABase
 """Get FullMachine ext."""
 get_ext(value::FullMachine) = value.ext
 """Get FullMachine inv_d_fluxlink."""
@@ -179,8 +172,6 @@ set_L_ff!(value::FullMachine, val::Float64) = value.L_ff = val
 set_L_1d!(value::FullMachine, val::Float64) = value.L_1d = val
 """Set FullMachine L_1q."""
 set_L_1q!(value::FullMachine, val::Float64) = value.L_1q = val
-"""Set FullMachine MVABase."""
-set_MVABase!(value::FullMachine, val::Float64) = value.MVABase = val
 """Set FullMachine ext."""
 set_ext!(value::FullMachine, val::Dict{String, Any}) = value.ext = val
 """Set FullMachine inv_d_fluxlink."""

--- a/src/models/generated/MarconatoMachine.jl
+++ b/src/models/generated/MarconatoMachine.jl
@@ -15,7 +15,6 @@ This file is auto-generated. Do not edit.
         Td0_pp::Float64
         Tq0_pp::Float64
         T_AA::Float64
-        MVABase::Float64
         ext::Dict{String, Any}
         γd::Float64
         γq::Float64
@@ -39,7 +38,6 @@ Parameters of 6-states synchronous machine: Marconato model
 - `Td0_pp::Float64`: Time constant of sub-transient d-axis voltage, validation range: (0, nothing)
 - `Tq0_pp::Float64`: Time constant of sub-transient q-axis voltage, validation range: (0, nothing)
 - `T_AA::Float64`: Time constant of d-axis additional leakage, validation range: (0, nothing)
-- `MVABase::Float64`: Nominal Capacity in MVA, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `γd::Float64`
 - `γq::Float64`
@@ -72,8 +70,6 @@ mutable struct MarconatoMachine <: Machine
     Tq0_pp::Float64
     "Time constant of d-axis additional leakage"
     T_AA::Float64
-    "Nominal Capacity in MVA"
-    MVABase::Float64
     ext::Dict{String, Any}
     γd::Float64
     γq::Float64
@@ -83,12 +79,12 @@ mutable struct MarconatoMachine <: Machine
     internal::InfrastructureSystemsInternal
 end
 
-function MarconatoMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, MVABase, ext=Dict{String, Any}(), )
-    MarconatoMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, MVABase, ext, ((Td0_pp*Xd_pp)/(Td0_p*Xd_p) )*(Xd-Xd_p), ((Tq0_pp*Xq_pp)/(Tq0_p*Xq_p) )*(Xq-Xq_p), [:ψq, :ψd, :eq_p, :ed_p, :eq_pp, :ed_pp], 6, InfrastructureSystemsInternal(), )
+function MarconatoMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, ext=Dict{String, Any}(), )
+    MarconatoMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, ext, ((Td0_pp*Xd_pp)/(Td0_p*Xd_p) )*(Xd-Xd_p), ((Tq0_pp*Xq_pp)/(Tq0_p*Xq_p) )*(Xq-Xq_p), [:ψq, :ψd, :eq_p, :ed_p, :eq_pp, :ed_pp], 6, InfrastructureSystemsInternal(), )
 end
 
-function MarconatoMachine(; R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, MVABase, ext=Dict{String, Any}(), )
-    MarconatoMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, MVABase, ext, )
+function MarconatoMachine(; R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, ext=Dict{String, Any}(), )
+    MarconatoMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -106,7 +102,6 @@ function MarconatoMachine(::Nothing)
         Td0_pp=0,
         Tq0_pp=0,
         T_AA=0,
-        MVABase=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -135,8 +130,6 @@ get_Td0_pp(value::MarconatoMachine) = value.Td0_pp
 get_Tq0_pp(value::MarconatoMachine) = value.Tq0_pp
 """Get MarconatoMachine T_AA."""
 get_T_AA(value::MarconatoMachine) = value.T_AA
-"""Get MarconatoMachine MVABase."""
-get_MVABase(value::MarconatoMachine) = value.MVABase
 """Get MarconatoMachine ext."""
 get_ext(value::MarconatoMachine) = value.ext
 """Get MarconatoMachine γd."""
@@ -174,8 +167,6 @@ set_Td0_pp!(value::MarconatoMachine, val::Float64) = value.Td0_pp = val
 set_Tq0_pp!(value::MarconatoMachine, val::Float64) = value.Tq0_pp = val
 """Set MarconatoMachine T_AA."""
 set_T_AA!(value::MarconatoMachine, val::Float64) = value.T_AA = val
-"""Set MarconatoMachine MVABase."""
-set_MVABase!(value::MarconatoMachine, val::Float64) = value.MVABase = val
 """Set MarconatoMachine ext."""
 set_ext!(value::MarconatoMachine, val::Dict{String, Any}) = value.ext = val
 """Set MarconatoMachine γd."""

--- a/src/models/generated/OneDOneQMachine.jl
+++ b/src/models/generated/OneDOneQMachine.jl
@@ -10,7 +10,6 @@ This file is auto-generated. Do not edit.
         Xq_p::Float64
         Td0_p::Float64
         Tq0_p::Float64
-        MVABase::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -30,7 +29,6 @@ Parameters of 4-states synchronous machine: Simplified Marconato model
 - `Xq_p::Float64`: Transient reactance after EMF in q-axis per unit, validation range: (0, nothing)
 - `Td0_p::Float64`: Time constant of transient d-axis voltage, validation range: (0, nothing)
 - `Tq0_p::Float64`: Time constant of transient q-axis voltage, validation range: (0, nothing)
-- `MVABase::Float64`: Nominal Capacity in MVA, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
 - `n_states::Int64`
@@ -51,8 +49,6 @@ mutable struct OneDOneQMachine <: Machine
     Td0_p::Float64
     "Time constant of transient q-axis voltage"
     Tq0_p::Float64
-    "Nominal Capacity in MVA"
-    MVABase::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
     n_states::Int64
@@ -60,12 +56,12 @@ mutable struct OneDOneQMachine <: Machine
     internal::InfrastructureSystemsInternal
 end
 
-function OneDOneQMachine(R, Xd, Xq, Xd_p, Xq_p, Td0_p, Tq0_p, MVABase, ext=Dict{String, Any}(), )
-    OneDOneQMachine(R, Xd, Xq, Xd_p, Xq_p, Td0_p, Tq0_p, MVABase, ext, [:eq_p, :ed_p], 2, InfrastructureSystemsInternal(), )
+function OneDOneQMachine(R, Xd, Xq, Xd_p, Xq_p, Td0_p, Tq0_p, ext=Dict{String, Any}(), )
+    OneDOneQMachine(R, Xd, Xq, Xd_p, Xq_p, Td0_p, Tq0_p, ext, [:eq_p, :ed_p], 2, InfrastructureSystemsInternal(), )
 end
 
-function OneDOneQMachine(; R, Xd, Xq, Xd_p, Xq_p, Td0_p, Tq0_p, MVABase, ext=Dict{String, Any}(), )
-    OneDOneQMachine(R, Xd, Xq, Xd_p, Xq_p, Td0_p, Tq0_p, MVABase, ext, )
+function OneDOneQMachine(; R, Xd, Xq, Xd_p, Xq_p, Td0_p, Tq0_p, ext=Dict{String, Any}(), )
+    OneDOneQMachine(R, Xd, Xq, Xd_p, Xq_p, Td0_p, Tq0_p, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -78,7 +74,6 @@ function OneDOneQMachine(::Nothing)
         Xq_p=0,
         Td0_p=0,
         Tq0_p=0,
-        MVABase=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -97,8 +92,6 @@ get_Xq_p(value::OneDOneQMachine) = value.Xq_p
 get_Td0_p(value::OneDOneQMachine) = value.Td0_p
 """Get OneDOneQMachine Tq0_p."""
 get_Tq0_p(value::OneDOneQMachine) = value.Tq0_p
-"""Get OneDOneQMachine MVABase."""
-get_MVABase(value::OneDOneQMachine) = value.MVABase
 """Get OneDOneQMachine ext."""
 get_ext(value::OneDOneQMachine) = value.ext
 """Get OneDOneQMachine states."""
@@ -122,8 +115,6 @@ set_Xq_p!(value::OneDOneQMachine, val::Float64) = value.Xq_p = val
 set_Td0_p!(value::OneDOneQMachine, val::Float64) = value.Td0_p = val
 """Set OneDOneQMachine Tq0_p."""
 set_Tq0_p!(value::OneDOneQMachine, val::Float64) = value.Tq0_p = val
-"""Set OneDOneQMachine MVABase."""
-set_MVABase!(value::OneDOneQMachine, val::Float64) = value.MVABase = val
 """Set OneDOneQMachine ext."""
 set_ext!(value::OneDOneQMachine, val::Dict{String, Any}) = value.ext = val
 """Set OneDOneQMachine states."""

--- a/src/models/generated/ReactivePowerDroop.jl
+++ b/src/models/generated/ReactivePowerDroop.jl
@@ -5,6 +5,7 @@ This file is auto-generated. Do not edit.
     mutable struct ReactivePowerDroop <: ReactivePowerControl
         kq::Float64
         ωf::Float64
+        V_ref::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -15,6 +16,7 @@ Parameters of a Reactive Power droop controller
 # Arguments
 - `kq::Float64`: frequency droop gain, validation range: (0, nothing)
 - `ωf::Float64`: filter frequency cutoff, validation range: (0, nothing)
+- `V_ref::Float64`: Reference Voltage Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
 - `n_states::Int64`
@@ -24,17 +26,19 @@ mutable struct ReactivePowerDroop <: ReactivePowerControl
     kq::Float64
     "filter frequency cutoff"
     ωf::Float64
+    "Reference Voltage Set-point"
+    V_ref::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
     n_states::Int64
 end
 
-function ReactivePowerDroop(kq, ωf, ext=Dict{String, Any}(), )
-    ReactivePowerDroop(kq, ωf, ext, [:q_oc], 1, )
+function ReactivePowerDroop(kq, ωf, V_ref=1.0, ext=Dict{String, Any}(), )
+    ReactivePowerDroop(kq, ωf, V_ref, ext, [:q_oc], 1, )
 end
 
-function ReactivePowerDroop(; kq, ωf, ext=Dict{String, Any}(), )
-    ReactivePowerDroop(kq, ωf, ext, )
+function ReactivePowerDroop(; kq, ωf, V_ref=1.0, ext=Dict{String, Any}(), )
+    ReactivePowerDroop(kq, ωf, V_ref, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -42,6 +46,7 @@ function ReactivePowerDroop(::Nothing)
     ReactivePowerDroop(;
         kq=0,
         ωf=0,
+        V_ref=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -50,6 +55,8 @@ end
 get_kq(value::ReactivePowerDroop) = value.kq
 """Get ReactivePowerDroop ωf."""
 get_ωf(value::ReactivePowerDroop) = value.ωf
+"""Get ReactivePowerDroop V_ref."""
+get_V_ref(value::ReactivePowerDroop) = value.V_ref
 """Get ReactivePowerDroop ext."""
 get_ext(value::ReactivePowerDroop) = value.ext
 """Get ReactivePowerDroop states."""
@@ -61,6 +68,8 @@ get_n_states(value::ReactivePowerDroop) = value.n_states
 set_kq!(value::ReactivePowerDroop, val::Float64) = value.kq = val
 """Set ReactivePowerDroop ωf."""
 set_ωf!(value::ReactivePowerDroop, val::Float64) = value.ωf = val
+"""Set ReactivePowerDroop V_ref."""
+set_V_ref!(value::ReactivePowerDroop, val::Float64) = value.V_ref = val
 """Set ReactivePowerDroop ext."""
 set_ext!(value::ReactivePowerDroop, val::Dict{String, Any}) = value.ext = val
 """Set ReactivePowerDroop states."""

--- a/src/models/generated/SimpleAFMachine.jl
+++ b/src/models/generated/SimpleAFMachine.jl
@@ -14,7 +14,6 @@ This file is auto-generated. Do not edit.
         Tq0_p::Float64
         Td0_pp::Float64
         Tq0_pp::Float64
-        MVABase::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -39,7 +38,6 @@ Parameters of 4-states simplified Anderson-Fouad (SimpleAFMachine) model.
 - `Tq0_p::Float64`: Time constant of transient q-axis voltage, validation range: (0, nothing)
 - `Td0_pp::Float64`: Time constant of sub-transient d-axis voltage, validation range: (0, nothing)
 - `Tq0_pp::Float64`: Time constant of sub-transient q-axis voltage, validation range: (0, nothing)
-- `MVABase::Float64`: Nominal Capacity in MVA, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
 - `n_states::Int64`
@@ -68,8 +66,6 @@ mutable struct SimpleAFMachine <: Machine
     Td0_pp::Float64
     "Time constant of sub-transient q-axis voltage"
     Tq0_pp::Float64
-    "Nominal Capacity in MVA"
-    MVABase::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
     n_states::Int64
@@ -77,12 +73,12 @@ mutable struct SimpleAFMachine <: Machine
     internal::InfrastructureSystemsInternal
 end
 
-function SimpleAFMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, MVABase, ext=Dict{String, Any}(), )
-    SimpleAFMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, MVABase, ext, [:eq_p, :ed_p, :eq_pp, :ed_pp], 4, InfrastructureSystemsInternal(), )
+function SimpleAFMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, ext=Dict{String, Any}(), )
+    SimpleAFMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, ext, [:eq_p, :ed_p, :eq_pp, :ed_pp], 4, InfrastructureSystemsInternal(), )
 end
 
-function SimpleAFMachine(; R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, MVABase, ext=Dict{String, Any}(), )
-    SimpleAFMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, MVABase, ext, )
+function SimpleAFMachine(; R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, ext=Dict{String, Any}(), )
+    SimpleAFMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -99,7 +95,6 @@ function SimpleAFMachine(::Nothing)
         Tq0_p=0,
         Td0_pp=0,
         Tq0_pp=0,
-        MVABase=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -126,8 +121,6 @@ get_Tq0_p(value::SimpleAFMachine) = value.Tq0_p
 get_Td0_pp(value::SimpleAFMachine) = value.Td0_pp
 """Get SimpleAFMachine Tq0_pp."""
 get_Tq0_pp(value::SimpleAFMachine) = value.Tq0_pp
-"""Get SimpleAFMachine MVABase."""
-get_MVABase(value::SimpleAFMachine) = value.MVABase
 """Get SimpleAFMachine ext."""
 get_ext(value::SimpleAFMachine) = value.ext
 """Get SimpleAFMachine states."""
@@ -159,8 +152,6 @@ set_Tq0_p!(value::SimpleAFMachine, val::Float64) = value.Tq0_p = val
 set_Td0_pp!(value::SimpleAFMachine, val::Float64) = value.Td0_pp = val
 """Set SimpleAFMachine Tq0_pp."""
 set_Tq0_pp!(value::SimpleAFMachine, val::Float64) = value.Tq0_pp = val
-"""Set SimpleAFMachine MVABase."""
-set_MVABase!(value::SimpleAFMachine, val::Float64) = value.MVABase = val
 """Set SimpleAFMachine ext."""
 set_ext!(value::SimpleAFMachine, val::Dict{String, Any}) = value.ext = val
 """Set SimpleAFMachine states."""

--- a/src/models/generated/SimpleFullMachine.jl
+++ b/src/models/generated/SimpleFullMachine.jl
@@ -15,7 +15,6 @@ This file is auto-generated. Do not edit.
         L_ff::Float64
         L_1d::Float64
         L_1q::Float64
-        MVABase::Float64
         ext::Dict{String, Any}
         inv_d_fluxlink::Array{Float64,2}
         inv_q_fluxlink::Array{Float64,2}
@@ -44,7 +43,6 @@ Parameter of a full order flux stator-rotor model without zero sequence flux in 
 - `L_ff::Float64`: Field rotor winding inductance, in per unit, validation range: (0, nothing)
 - `L_1d::Float64`: Inductance of the d-axis rotor damping circuit, in per unit, validation range: (0, nothing)
 - `L_1q::Float64`: Inductance of the q-axis rotor damping circuit, in per unit, validation range: (0, nothing)
-- `MVABase::Float64`: Nominal Capacity in MVA, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `inv_d_fluxlink::Array{Float64,2}`: Equations 3.127, 3.130, 3.131 From Kundur
 - `inv_q_fluxlink::Array{Float64,2}`: Equations 3.128, 3.132 From Kundur
@@ -77,8 +75,6 @@ mutable struct SimpleFullMachine <: Machine
     L_1d::Float64
     "Inductance of the q-axis rotor damping circuit, in per unit"
     L_1q::Float64
-    "Nominal Capacity in MVA"
-    MVABase::Float64
     ext::Dict{String, Any}
     "Equations 3.127, 3.130, 3.131 From Kundur"
     inv_d_fluxlink::Array{Float64,2}
@@ -90,12 +86,12 @@ mutable struct SimpleFullMachine <: Machine
     internal::InfrastructureSystemsInternal
 end
 
-function SimpleFullMachine(R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, MVABase, ext=Dict{String, Any}(), )
-    SimpleFullMachine(R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, MVABase, ext, inv([[-L_d L_ad L_ad]; [-L_ad L_ff L_f1d]; [-L_ad L_f1d L_1d]]), inv([[-L_q L_aq]; [-L_aq L_1q]]), [:ψf, :ψ1d, :ψ1q], 3, InfrastructureSystemsInternal(), )
+function SimpleFullMachine(R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, ext=Dict{String, Any}(), )
+    SimpleFullMachine(R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, ext, inv([[-L_d L_ad L_ad]; [-L_ad L_ff L_f1d]; [-L_ad L_f1d L_1d]]), inv([[-L_q L_aq]; [-L_aq L_1q]]), [:ψf, :ψ1d, :ψ1q], 3, InfrastructureSystemsInternal(), )
 end
 
-function SimpleFullMachine(; R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, MVABase, ext=Dict{String, Any}(), )
-    SimpleFullMachine(R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, MVABase, ext, )
+function SimpleFullMachine(; R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, ext=Dict{String, Any}(), )
+    SimpleFullMachine(R, R_f, R_1d, R_1q, L_d, L_q, L_ad, L_aq, L_f1d, L_ff, L_1d, L_1q, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -113,7 +109,6 @@ function SimpleFullMachine(::Nothing)
         L_ff=2.0,
         L_1d=1.0,
         L_1q=2.0,
-        MVABase=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -142,8 +137,6 @@ get_L_ff(value::SimpleFullMachine) = value.L_ff
 get_L_1d(value::SimpleFullMachine) = value.L_1d
 """Get SimpleFullMachine L_1q."""
 get_L_1q(value::SimpleFullMachine) = value.L_1q
-"""Get SimpleFullMachine MVABase."""
-get_MVABase(value::SimpleFullMachine) = value.MVABase
 """Get SimpleFullMachine ext."""
 get_ext(value::SimpleFullMachine) = value.ext
 """Get SimpleFullMachine inv_d_fluxlink."""
@@ -181,8 +174,6 @@ set_L_ff!(value::SimpleFullMachine, val::Float64) = value.L_ff = val
 set_L_1d!(value::SimpleFullMachine, val::Float64) = value.L_1d = val
 """Set SimpleFullMachine L_1q."""
 set_L_1q!(value::SimpleFullMachine, val::Float64) = value.L_1q = val
-"""Set SimpleFullMachine MVABase."""
-set_MVABase!(value::SimpleFullMachine, val::Float64) = value.MVABase = val
 """Set SimpleFullMachine ext."""
 set_ext!(value::SimpleFullMachine, val::Dict{String, Any}) = value.ext = val
 """Set SimpleFullMachine inv_d_fluxlink."""

--- a/src/models/generated/SimpleMarconatoMachine.jl
+++ b/src/models/generated/SimpleMarconatoMachine.jl
@@ -15,7 +15,6 @@ This file is auto-generated. Do not edit.
         Td0_pp::Float64
         Tq0_pp::Float64
         T_AA::Float64
-        MVABase::Float64
         ext::Dict{String, Any}
         γd::Float64
         γq::Float64
@@ -42,7 +41,6 @@ Parameters of 4-states synchronous machine: Simplified Marconato model
 - `Td0_pp::Float64`: Time constant of sub-transient d-axis voltage, validation range: (0, nothing)
 - `Tq0_pp::Float64`: Time constant of sub-transient q-axis voltage, validation range: (0, nothing)
 - `T_AA::Float64`: Time constant of d-axis additional leakage, validation range: (0, nothing)
-- `MVABase::Float64`: Nominal Capacity in MVA, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `γd::Float64`
 - `γq::Float64`
@@ -75,8 +73,6 @@ mutable struct SimpleMarconatoMachine <: Machine
     Tq0_pp::Float64
     "Time constant of d-axis additional leakage"
     T_AA::Float64
-    "Nominal Capacity in MVA"
-    MVABase::Float64
     ext::Dict{String, Any}
     γd::Float64
     γq::Float64
@@ -86,12 +82,12 @@ mutable struct SimpleMarconatoMachine <: Machine
     internal::InfrastructureSystemsInternal
 end
 
-function SimpleMarconatoMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, MVABase, ext=Dict{String, Any}(), )
-    SimpleMarconatoMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, MVABase, ext, ((Td0_pp*Xd_pp)/(Td0_p*Xd_p) )*(Xd-Xd_p), ((Tq0_pp*Xq_pp)/(Tq0_p*Xq_p) )*(Xq-Xq_p), [:eq_p, :ed_p, :eq_pp, :ed_pp], 4, InfrastructureSystemsInternal(), )
+function SimpleMarconatoMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, ext=Dict{String, Any}(), )
+    SimpleMarconatoMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, ext, ((Td0_pp*Xd_pp)/(Td0_p*Xd_p) )*(Xd-Xd_p), ((Tq0_pp*Xq_pp)/(Tq0_p*Xq_p) )*(Xq-Xq_p), [:eq_p, :ed_p, :eq_pp, :ed_pp], 4, InfrastructureSystemsInternal(), )
 end
 
-function SimpleMarconatoMachine(; R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, MVABase, ext=Dict{String, Any}(), )
-    SimpleMarconatoMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, MVABase, ext, )
+function SimpleMarconatoMachine(; R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, ext=Dict{String, Any}(), )
+    SimpleMarconatoMachine(R, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xq_pp, Td0_p, Tq0_p, Td0_pp, Tq0_pp, T_AA, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -109,7 +105,6 @@ function SimpleMarconatoMachine(::Nothing)
         Td0_pp=0,
         Tq0_pp=0,
         T_AA=0,
-        MVABase=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -138,8 +133,6 @@ get_Td0_pp(value::SimpleMarconatoMachine) = value.Td0_pp
 get_Tq0_pp(value::SimpleMarconatoMachine) = value.Tq0_pp
 """Get SimpleMarconatoMachine T_AA."""
 get_T_AA(value::SimpleMarconatoMachine) = value.T_AA
-"""Get SimpleMarconatoMachine MVABase."""
-get_MVABase(value::SimpleMarconatoMachine) = value.MVABase
 """Get SimpleMarconatoMachine ext."""
 get_ext(value::SimpleMarconatoMachine) = value.ext
 """Get SimpleMarconatoMachine γd."""
@@ -177,8 +170,6 @@ set_Td0_pp!(value::SimpleMarconatoMachine, val::Float64) = value.Td0_pp = val
 set_Tq0_pp!(value::SimpleMarconatoMachine, val::Float64) = value.Tq0_pp = val
 """Set SimpleMarconatoMachine T_AA."""
 set_T_AA!(value::SimpleMarconatoMachine, val::Float64) = value.T_AA = val
-"""Set SimpleMarconatoMachine MVABase."""
-set_MVABase!(value::SimpleMarconatoMachine, val::Float64) = value.MVABase = val
 """Set SimpleMarconatoMachine ext."""
 set_ext!(value::SimpleMarconatoMachine, val::Dict{String, Any}) = value.ext = val
 """Set SimpleMarconatoMachine γd."""

--- a/src/models/generated/TGFixed.jl
+++ b/src/models/generated/TGFixed.jl
@@ -4,6 +4,7 @@ This file is auto-generated. Do not edit.
 """
     mutable struct TGFixed <: TurbineGov
         efficiency::Float64
+        P_ref::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -15,6 +16,7 @@ Parameters of a fixed Turbine Governor that returns a fixed mechanical torque
 
 # Arguments
 - `efficiency::Float64`:  Efficiency factor that multiplies P_ref, validation range: (0, nothing)
+- `P_ref::Float64`: Reference Power Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
 - `n_states::Int64`
@@ -23,6 +25,8 @@ Parameters of a fixed Turbine Governor that returns a fixed mechanical torque
 mutable struct TGFixed <: TurbineGov
     " Efficiency factor that multiplies P_ref"
     efficiency::Float64
+    "Reference Power Set-point"
+    P_ref::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
     n_states::Int64
@@ -30,24 +34,27 @@ mutable struct TGFixed <: TurbineGov
     internal::InfrastructureSystemsInternal
 end
 
-function TGFixed(efficiency, ext=Dict{String, Any}(), )
-    TGFixed(efficiency, ext, Vector{Symbol}(), 0, InfrastructureSystemsInternal(), )
+function TGFixed(efficiency, P_ref=1.0, ext=Dict{String, Any}(), )
+    TGFixed(efficiency, P_ref, ext, Vector{Symbol}(), 0, InfrastructureSystemsInternal(), )
 end
 
-function TGFixed(; efficiency, ext=Dict{String, Any}(), )
-    TGFixed(efficiency, ext, )
+function TGFixed(; efficiency, P_ref=1.0, ext=Dict{String, Any}(), )
+    TGFixed(efficiency, P_ref, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
 function TGFixed(::Nothing)
     TGFixed(;
         efficiency=0,
+        P_ref=0,
         ext=Dict{String, Any}(),
     )
 end
 
 """Get TGFixed efficiency."""
 get_efficiency(value::TGFixed) = value.efficiency
+"""Get TGFixed P_ref."""
+get_P_ref(value::TGFixed) = value.P_ref
 """Get TGFixed ext."""
 get_ext(value::TGFixed) = value.ext
 """Get TGFixed states."""
@@ -59,6 +66,8 @@ get_internal(value::TGFixed) = value.internal
 
 """Set TGFixed efficiency."""
 set_efficiency!(value::TGFixed, val::Float64) = value.efficiency = val
+"""Set TGFixed P_ref."""
+set_P_ref!(value::TGFixed, val::Float64) = value.P_ref = val
 """Set TGFixed ext."""
 set_ext!(value::TGFixed, val::Dict{String, Any}) = value.ext = val
 """Set TGFixed states."""

--- a/src/models/generated/TGTypeI.jl
+++ b/src/models/generated/TGTypeI.jl
@@ -11,6 +11,7 @@ This file is auto-generated. Do not edit.
         T5::Float64
         P_min::Float64
         P_max::Float64
+        P_ref::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -28,6 +29,7 @@ Parameters of a Turbine Governor Type I.
 - `T5::Float64`: Reheat time constant, validation range: (0, nothing)
 - `P_min::Float64`: Min Power into the Governor, validation range: (0, nothing)
 - `P_max::Float64`: Max Power into the Governor, validation range: (0, nothing)
+- `P_ref::Float64`: Reference Power Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
 - `n_states::Int64`
@@ -50,6 +52,8 @@ mutable struct TGTypeI <: TurbineGov
     P_min::Float64
     "Max Power into the Governor"
     P_max::Float64
+    "Reference Power Set-point"
+    P_ref::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
     n_states::Int64
@@ -57,12 +61,12 @@ mutable struct TGTypeI <: TurbineGov
     internal::InfrastructureSystemsInternal
 end
 
-function TGTypeI(R, Ts, Tc, T3, T4, T5, P_min, P_max, ext=Dict{String, Any}(), )
-    TGTypeI(R, Ts, Tc, T3, T4, T5, P_min, P_max, ext, [:x_g1, :x_g2, :x_g3], 3, InfrastructureSystemsInternal(), )
+function TGTypeI(R, Ts, Tc, T3, T4, T5, P_min, P_max, P_ref=1.0, ext=Dict{String, Any}(), )
+    TGTypeI(R, Ts, Tc, T3, T4, T5, P_min, P_max, P_ref, ext, [:x_g1, :x_g2, :x_g3], 3, InfrastructureSystemsInternal(), )
 end
 
-function TGTypeI(; R, Ts, Tc, T3, T4, T5, P_min, P_max, ext=Dict{String, Any}(), )
-    TGTypeI(R, Ts, Tc, T3, T4, T5, P_min, P_max, ext, )
+function TGTypeI(; R, Ts, Tc, T3, T4, T5, P_min, P_max, P_ref=1.0, ext=Dict{String, Any}(), )
+    TGTypeI(R, Ts, Tc, T3, T4, T5, P_min, P_max, P_ref, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -76,6 +80,7 @@ function TGTypeI(::Nothing)
         T5=0,
         P_min=0,
         P_max=0,
+        P_ref=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -96,6 +101,8 @@ get_T5(value::TGTypeI) = value.T5
 get_P_min(value::TGTypeI) = value.P_min
 """Get TGTypeI P_max."""
 get_P_max(value::TGTypeI) = value.P_max
+"""Get TGTypeI P_ref."""
+get_P_ref(value::TGTypeI) = value.P_ref
 """Get TGTypeI ext."""
 get_ext(value::TGTypeI) = value.ext
 """Get TGTypeI states."""
@@ -121,6 +128,8 @@ set_T5!(value::TGTypeI, val::Float64) = value.T5 = val
 set_P_min!(value::TGTypeI, val::Float64) = value.P_min = val
 """Set TGTypeI P_max."""
 set_P_max!(value::TGTypeI, val::Float64) = value.P_max = val
+"""Set TGTypeI P_ref."""
+set_P_ref!(value::TGTypeI, val::Float64) = value.P_ref = val
 """Set TGTypeI ext."""
 set_ext!(value::TGTypeI, val::Dict{String, Any}) = value.ext = val
 """Set TGTypeI states."""

--- a/src/models/generated/TGTypeII.jl
+++ b/src/models/generated/TGTypeII.jl
@@ -8,6 +8,7 @@ This file is auto-generated. Do not edit.
         T2::Float64
         τ_min::Float64
         τ_max::Float64
+        P_ref::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -22,6 +23,7 @@ Parameters of a Turbine Governor Type II.
 - `T2::Float64`: Power fraction time constant, validation range: (0, nothing)
 - `τ_min::Float64`: Min Power into the Governor, validation range: (0, nothing)
 - `τ_max::Float64`: Max Power into the Governor, validation range: (0, nothing)
+- `P_ref::Float64`: Reference Power Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
 - `n_states::Int64`
@@ -38,6 +40,8 @@ mutable struct TGTypeII <: TurbineGov
     τ_min::Float64
     "Max Power into the Governor"
     τ_max::Float64
+    "Reference Power Set-point"
+    P_ref::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
     n_states::Int64
@@ -45,12 +49,12 @@ mutable struct TGTypeII <: TurbineGov
     internal::InfrastructureSystemsInternal
 end
 
-function TGTypeII(R, T1, T2, τ_min, τ_max, ext=Dict{String, Any}(), )
-    TGTypeII(R, T1, T2, τ_min, τ_max, ext, [:xg], 1, InfrastructureSystemsInternal(), )
+function TGTypeII(R, T1, T2, τ_min, τ_max, P_ref=1.0, ext=Dict{String, Any}(), )
+    TGTypeII(R, T1, T2, τ_min, τ_max, P_ref, ext, [:xg], 1, InfrastructureSystemsInternal(), )
 end
 
-function TGTypeII(; R, T1, T2, τ_min, τ_max, ext=Dict{String, Any}(), )
-    TGTypeII(R, T1, T2, τ_min, τ_max, ext, )
+function TGTypeII(; R, T1, T2, τ_min, τ_max, P_ref=1.0, ext=Dict{String, Any}(), )
+    TGTypeII(R, T1, T2, τ_min, τ_max, P_ref, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -61,6 +65,7 @@ function TGTypeII(::Nothing)
         T2=0,
         τ_min=0,
         τ_max=0,
+        P_ref=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -75,6 +80,8 @@ get_T2(value::TGTypeII) = value.T2
 get_τ_min(value::TGTypeII) = value.τ_min
 """Get TGTypeII τ_max."""
 get_τ_max(value::TGTypeII) = value.τ_max
+"""Get TGTypeII P_ref."""
+get_P_ref(value::TGTypeII) = value.P_ref
 """Get TGTypeII ext."""
 get_ext(value::TGTypeII) = value.ext
 """Get TGTypeII states."""
@@ -94,6 +101,8 @@ set_T2!(value::TGTypeII, val::Float64) = value.T2 = val
 set_τ_min!(value::TGTypeII, val::Float64) = value.τ_min = val
 """Set TGTypeII τ_max."""
 set_τ_max!(value::TGTypeII, val::Float64) = value.τ_max = val
+"""Set TGTypeII P_ref."""
+set_P_ref!(value::TGTypeII, val::Float64) = value.P_ref = val
 """Set TGTypeII ext."""
 set_ext!(value::TGTypeII, val::Dict{String, Any}) = value.ext = val
 """Set TGTypeII states."""

--- a/src/models/generated/VirtualInertia.jl
+++ b/src/models/generated/VirtualInertia.jl
@@ -6,7 +6,7 @@ This file is auto-generated. Do not edit.
         Ta::Float64
         kd::Float64
         kω::Float64
-        ωb::Float64
+        P_ref::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
@@ -18,7 +18,7 @@ Parameters of a Virtual Inertia with SRF using VSM for active power controller
 - `Ta::Float64`: VSM inertia constant, validation range: (0, nothing)
 - `kd::Float64`: VSM damping constant, validation range: (0, nothing)
 - `kω::Float64`: frequency droop gain, validation range: (0, nothing)
-- `ωb::Float64`: rated angular frequency, validation range: (0, nothing)
+- `P_ref::Float64`: Reference Power Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
 - `n_states::Int64`
@@ -30,19 +30,19 @@ mutable struct VirtualInertia <: ActivePowerControl
     kd::Float64
     "frequency droop gain"
     kω::Float64
-    "rated angular frequency"
-    ωb::Float64
+    "Reference Power Set-point"
+    P_ref::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
     n_states::Int64
 end
 
-function VirtualInertia(Ta, kd, kω, ωb, ext=Dict{String, Any}(), )
-    VirtualInertia(Ta, kd, kω, ωb, ext, [:ω_oc, :θ_oc], 2, )
+function VirtualInertia(Ta, kd, kω, P_ref=1.0, ext=Dict{String, Any}(), )
+    VirtualInertia(Ta, kd, kω, P_ref, ext, [:ω_oc, :θ_oc], 2, )
 end
 
-function VirtualInertia(; Ta, kd, kω, ωb, ext=Dict{String, Any}(), )
-    VirtualInertia(Ta, kd, kω, ωb, ext, )
+function VirtualInertia(; Ta, kd, kω, P_ref=1.0, ext=Dict{String, Any}(), )
+    VirtualInertia(Ta, kd, kω, P_ref, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -51,7 +51,7 @@ function VirtualInertia(::Nothing)
         Ta=0,
         kd=0,
         kω=0,
-        ωb=0,
+        P_ref=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -62,8 +62,8 @@ get_Ta(value::VirtualInertia) = value.Ta
 get_kd(value::VirtualInertia) = value.kd
 """Get VirtualInertia kω."""
 get_kω(value::VirtualInertia) = value.kω
-"""Get VirtualInertia ωb."""
-get_ωb(value::VirtualInertia) = value.ωb
+"""Get VirtualInertia P_ref."""
+get_P_ref(value::VirtualInertia) = value.P_ref
 """Get VirtualInertia ext."""
 get_ext(value::VirtualInertia) = value.ext
 """Get VirtualInertia states."""
@@ -77,8 +77,8 @@ set_Ta!(value::VirtualInertia, val::Float64) = value.Ta = val
 set_kd!(value::VirtualInertia, val::Float64) = value.kd = val
 """Set VirtualInertia kω."""
 set_kω!(value::VirtualInertia, val::Float64) = value.kω = val
-"""Set VirtualInertia ωb."""
-set_ωb!(value::VirtualInertia, val::Float64) = value.ωb = val
+"""Set VirtualInertia P_ref."""
+set_P_ref!(value::VirtualInertia, val::Float64) = value.P_ref = val
 """Set VirtualInertia ext."""
 set_ext!(value::VirtualInertia, val::Dict{String, Any}) = value.ext = val
 """Set VirtualInertia states."""

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -65,7 +65,6 @@ export get_D_ex
 export get_D_hp
 export get_D_ip
 export get_D_lp
-export get_Emf
 export get_H
 export get_H_ex
 export get_H_hp
@@ -92,9 +91,9 @@ export get_L_d
 export get_L_f1d
 export get_L_ff
 export get_L_q
-export get_MVABase
 export get_P_max
 export get_P_min
+export get_P_ref
 export get_R
 export get_R_1d
 export get_R_1q
@@ -116,6 +115,7 @@ export get_Tq0_pp
 export get_Tr
 export get_Ts
 export get_V_pss
+export get_V_ref
 export get_Vr_max
 export get_Vr_min
 export get_X_th
@@ -231,7 +231,6 @@ export get_τ_max
 export get_τ_min
 export get_ω_lp
 export get_ωad
-export get_ωb
 export get_ωf
 export set_Ae!
 export set_Be!
@@ -244,7 +243,6 @@ export set_D_ex!
 export set_D_hp!
 export set_D_ip!
 export set_D_lp!
-export set_Emf!
 export set_H!
 export set_H_ex!
 export set_H_hp!
@@ -271,9 +269,9 @@ export set_L_d!
 export set_L_f1d!
 export set_L_ff!
 export set_L_q!
-export set_MVABase!
 export set_P_max!
 export set_P_min!
+export set_P_ref!
 export set_R!
 export set_R_1d!
 export set_R_1q!
@@ -295,6 +293,7 @@ export set_Tq0_pp!
 export set_Tr!
 export set_Ts!
 export set_V_pss!
+export set_V_ref!
 export set_Vr_max!
 export set_Vr_min!
 export set_X_th!
@@ -410,5 +409,4 @@ export set_τ_max!
 export set_τ_min!
 export set_ω_lp!
 export set_ωad!
-export set_ωb!
 export set_ωf!

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -116,6 +116,7 @@ export get_Tr
 export get_Ts
 export get_V_pss
 export get_V_ref
+export get_Vf
 export get_Vr_max
 export get_Vr_min
 export get_X_th
@@ -294,6 +295,7 @@ export set_Tr!
 export set_Ts!
 export set_V_pss!
 export set_V_ref!
+export set_Vf!
 export set_Vr_max!
 export set_Vr_min!
 export set_X_th!

--- a/test/test_dynamic_generator.jl
+++ b/test/test_dynamic_generator.jl
@@ -49,8 +49,7 @@ branch_OMIB = [Line(
         0.0, #R
         0.2995, #Xd_p
         1.05, #eq_p
-        615.0,
-    )  #MVABase
+    ) 
     @test Basic isa PowerSystems.DynamicComponent
 
     oneDoneQ = OneDOneQMachine(
@@ -61,8 +60,7 @@ branch_OMIB = [Line(
         0.04, #Xq_p
         7.4, #Td0_p
         0.033, #Tq0_p
-        615.0,
-    )   #MVABase
+    )   
     @test oneDoneQ isa PowerSystems.DynamicComponent
 
     AndersonFouad = AndersonFouadMachine(
@@ -77,8 +75,7 @@ branch_OMIB = [Line(
         0.01, #Tq0_p #Data not available in Milano: Used 0.01
         0.03, #Td0_pp
         0.033, #Tq0_pp
-        615.0,
-    ) #MVABase
+    ) 
     @test AndersonFouad isa PowerSystems.DynamicComponent
 
     KundurMachine = SimpleFullMachine(
@@ -94,8 +91,7 @@ branch_OMIB = [Line(
         1.825, #L_ff
         0.1713, #L_1d or L_D in Machowski
         0.7525, #L_1q or L_Q in Machowski
-        555.0,
-    ) #MVABase
+    ) 
     @test KundurMachine isa PowerSystems.DynamicComponent
 
     KundurFullMachine = FullMachine(
@@ -112,8 +108,7 @@ branch_OMIB = [Line(
         1.825, #L_ff
         0.1713, #L_1d or L_D in Machowski
         0.7525, #L_1q or L_Q in Machowski
-        555.0,
-    ) #MVABase
+    ) 
     @test KundurFullMachine isa PowerSystems.DynamicComponent
 
     Mach2_benchmark = OneDOneQMachine(
@@ -124,8 +119,7 @@ branch_OMIB = [Line(
         0.25, #Xq_p
         5.89, #Td0_p
         0.6, #Tq0_p
-        100.0,
-    )   #MVABase
+    )   
     @test Mach2_benchmark isa PowerSystems.DynamicComponent
 end
 
@@ -178,7 +172,7 @@ end
         0.0, #T4
         50.0, #T5
         0.3, #P_min
-        1.2,
+        1.2, 
     ) #P_max
     @test typeI_tg isa PowerSystems.DynamicComponent
 
@@ -187,7 +181,7 @@ end
         0.3, #T1
         0.1, #T2
         1.0, #τ_max
-        0.1,
+        0.1, 
     ) #τ_min
     @test typeII_tg isa PowerSystems.DynamicComponent
 end
@@ -196,7 +190,7 @@ end
     proportional_avr = AVRSimple(5000.0) #Kv
     @test proportional_avr isa PowerSystems.DynamicComponent
 
-    fixed_avr = AVRFixed(1.05) #Emf
+    fixed_avr = AVRFixed(1.05) #V_ref
     @test fixed_avr isa PowerSystems.DynamicComponent
 
     typeI_avr = AVRTypeI(
@@ -225,7 +219,7 @@ end
         5.0, #Vrmax
         -5.0, #Vrmin
         0.0039, #Ae - 1st ceiling coefficient
-        1.555,
+        1.555, 
     ) #Be - 2nd ceiling coefficient
     @test gen2_avr_benchmark isa PowerSystems.DynamicComponent
 end
@@ -236,8 +230,7 @@ end
         0.0, #R
         0.2995, #Xd_p
         1.05, #eq_p
-        615.0,
-    )  #MVABase
+    ) 
 
     BaseShaft = SingleMass(
         5.148, #H
@@ -260,8 +253,7 @@ end
         0.04, #Xq_p
         7.4, #Td0_p
         0.033, #Tq0_p
-        615.0,
-    )   #MVABase
+    )   
 
     Gen1AVR = DynamicGenerator(
         static_gen,

--- a/test/test_dynamic_generator.jl
+++ b/test/test_dynamic_generator.jl
@@ -49,7 +49,7 @@ branch_OMIB = [Line(
         0.0, #R
         0.2995, #Xd_p
         1.05, #eq_p
-    ) 
+    )
     @test Basic isa PowerSystems.DynamicComponent
 
     oneDoneQ = OneDOneQMachine(
@@ -60,7 +60,7 @@ branch_OMIB = [Line(
         0.04, #Xq_p
         7.4, #Td0_p
         0.033, #Tq0_p
-    )   
+    )
     @test oneDoneQ isa PowerSystems.DynamicComponent
 
     AndersonFouad = AndersonFouadMachine(
@@ -75,7 +75,7 @@ branch_OMIB = [Line(
         0.01, #Tq0_p #Data not available in Milano: Used 0.01
         0.03, #Td0_pp
         0.033, #Tq0_pp
-    ) 
+    )
     @test AndersonFouad isa PowerSystems.DynamicComponent
 
     KundurMachine = SimpleFullMachine(
@@ -91,7 +91,7 @@ branch_OMIB = [Line(
         1.825, #L_ff
         0.1713, #L_1d or L_D in Machowski
         0.7525, #L_1q or L_Q in Machowski
-    ) 
+    )
     @test KundurMachine isa PowerSystems.DynamicComponent
 
     KundurFullMachine = FullMachine(
@@ -108,7 +108,7 @@ branch_OMIB = [Line(
         1.825, #L_ff
         0.1713, #L_1d or L_D in Machowski
         0.7525, #L_1q or L_Q in Machowski
-    ) 
+    )
     @test KundurFullMachine isa PowerSystems.DynamicComponent
 
     Mach2_benchmark = OneDOneQMachine(
@@ -119,7 +119,7 @@ branch_OMIB = [Line(
         0.25, #Xq_p
         5.89, #Td0_p
         0.6, #Tq0_p
-    )   
+    )
     @test Mach2_benchmark isa PowerSystems.DynamicComponent
 end
 
@@ -172,7 +172,7 @@ end
         0.0, #T4
         50.0, #T5
         0.3, #P_min
-        1.2, 
+        1.2,
     ) #P_max
     @test typeI_tg isa PowerSystems.DynamicComponent
 
@@ -181,7 +181,7 @@ end
         0.3, #T1
         0.1, #T2
         1.0, #τ_max
-        0.1, 
+        0.1,
     ) #τ_min
     @test typeII_tg isa PowerSystems.DynamicComponent
 end
@@ -219,7 +219,7 @@ end
         5.0, #Vrmax
         -5.0, #Vrmin
         0.0039, #Ae - 1st ceiling coefficient
-        1.555, 
+        1.555,
     ) #Be - 2nd ceiling coefficient
     @test gen2_avr_benchmark isa PowerSystems.DynamicComponent
 end
@@ -230,7 +230,7 @@ end
         0.0, #R
         0.2995, #Xd_p
         1.05, #eq_p
-    ) 
+    )
 
     BaseShaft = SingleMass(
         5.148, #H
@@ -253,7 +253,7 @@ end
         0.04, #Xq_p
         7.4, #Td0_p
         0.033, #Tq0_p
-    )   
+    )
 
     Gen1AVR = DynamicGenerator(
         static_gen,

--- a/test/test_dynamic_generator.jl
+++ b/test/test_dynamic_generator.jl
@@ -190,7 +190,7 @@ end
     proportional_avr = AVRSimple(5000.0) #Kv
     @test proportional_avr isa PowerSystems.DynamicComponent
 
-    fixed_avr = AVRFixed(1.05) #V_ref
+    fixed_avr = AVRFixed(1.05) #Vf
     @test fixed_avr isa PowerSystems.DynamicComponent
 
     typeI_avr = AVRTypeI(
@@ -237,7 +237,7 @@ end
         2.0,
     ) #D
 
-    fixed_avr = AVRFixed(1.05) #Emf
+    fixed_avr = AVRFixed(1.05) #Vf
 
     proportional_avr = AVRSimple(5000.0) #Kv
 


### PR DESCRIPTION
The following PR provides an update on the dynamic structures for better integration to the dynamic models.

The main changes are:

- Add `V_ref` to the AVR models and OuterControl models. This is a parameter that defaults to 1.0, and must be updated when initializing the dynamic model via the solution of the static Power Flow.
- Add `P_ref` to the TurbineGov models and OuterControl models. Also defaults to 1.0.
- Remove `MVABase` from machine. This parameter should be the same as the base power provided in the static generator structs.

Note that `V_ref` and `P_ref` are not necessarily the solution of the static power flow model. These parameters will depend on the specific dynamic models used, and must be updated in order to match solutions of the static PF with the initial condition of the dynamic model. The user should not (but could) interfere directly.