### PR TITLE
Fix serialization of area and load_zone in buses

### DIFF
--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -238,14 +238,14 @@
             {
                 "name": "area",
                 "comment": "the area containing the bus",
-                "null_value": "Area(nothing)",
+                "null_value": "nothing",
                 "data_type": "Union{Nothing, Area}",
                 "default": "nothing"
             },
             {
                 "name": "load_zone",
                 "comment": "the load zone containing the bus",
-                "null_value": "LoadZone(nothing)",
+                "null_value": "nothing",
                 "data_type": "Union{Nothing, LoadZone}",
                 "default": "nothing"
             },

--- a/src/models/generated/Bus.jl
+++ b/src/models/generated/Bus.jl
@@ -90,8 +90,8 @@ function Bus(::Nothing)
         voltage=0.0,
         voltagelimits=(min=0.0, max=0.0),
         basevoltage=nothing,
-        area=Area(nothing),
-        load_zone=LoadZone(nothing),
+        area=nothing,
+        load_zone=nothing,
         ext=Dict{String, Any}(),
     )
 end


### PR DESCRIPTION
This will definitely break deserialization from previous versions because we were storing areas and load zones as objects instead of UUIDs in the JSON.  We were also allowing addition of buses if attached areas and load zones were not part of the system.