### PR TITLE
[DNMY] Add GENROU/SAL models

### DIFF
--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2796,6 +2796,308 @@
         "supertype": "Machine"
     },
     {
+        "struct_name": "GENROU",
+        "docstring": "Parameters of 4-states round-rotor synchronous machine: GENROU model",
+        "fields": [
+            {
+                "name": "R",
+                "comment": "Armature resistance",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Td0_p",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of transient d-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Td0_pp",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of sub-transient d-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Tq0_p",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of transient q-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Tq0_pp",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of sub-transient q-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xd",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Reactance after EMF in d-axis per unit",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xq",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Reactance after EMF in q-axis per unit",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xd_p",
+                "comment": "Transient reactance after EMF in d-axis per unit",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xq_p",
+                "comment": "Transient reactance after EMF in q-axis per unit",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xd_pp",
+                "comment": "Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xl",
+                "comment": "Stator leakage reactance",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "S1_0",
+                "comment": "Saturation factor at 1 pu flux",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "S1_2",
+                "comment": "Saturation factor at 1 pu flux",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "ext",
+                "data_type": "Dict{String, Any}",
+                "null_value": "Dict{String, Any}()",
+                "default": "Dict{String, Any}()"
+            },
+            {
+                "name": "states",
+                "comment": "The states are:\n\teq_p: q-axis generator voltage behind the transient reactance,\n\ted_p: d-axis generator voltage behind the transient reactance,\n\tψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,\n\tψ_kq: flux linkage in the first equivalent damping circuit in the d-axis",
+                "internal_default": "[:eq_p, :ed_p, :ψ_kd, :ψ_kq]",
+                "data_type": "Vector{Symbol}"
+            },
+            {
+                "name": "n_states",
+                "comment": "",
+                "internal_default": 4,
+                "data_type": "Int64"
+            },
+            {
+                "name": "internal",
+                "comment": "power system internal reference, do not modify",
+                "data_type": "InfrastructureSystemsInternal",
+                "internal_default": "InfrastructureSystemsInternal()"
+            }
+        ],
+        "supertype": "Machine"
+    },
+    {
+        "struct_name": "GENSAL",
+        "docstring": "Parameters of 3-states salient-pole synchronous machine: GENSAL model",
+        "fields": [
+            {
+                "name": "R",
+                "comment": "Armature resistance",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Td0_p",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of transient d-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Td0_pp",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of sub-transient d-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Tq0_pp",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of sub-transient q-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xd",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Reactance after EMF in d-axis per unit",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xq",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Reactance after EMF in q-axis per unit",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xd_p",
+                "comment": "Transient reactance after EMF in d-axis per unit",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xd_pp",
+                "comment": "Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xl",
+                "comment": "Stator leakage reactance",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "S1_0",
+                "comment": "Saturation factor at 1 pu flux",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "S1_2",
+                "comment": "Saturation factor at 1 pu flux",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "ext",
+                "data_type": "Dict{String, Any}",
+                "null_value": "Dict{String, Any}()",
+                "default": "Dict{String, Any}()"
+            },
+            {
+                "name": "states",
+                "comment": "The states are:\n\teq_p: q-axis generator voltage behind the transient reactance,\n\tψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,\n\tψq_pp: phasonf of the subtransient flux linkage in the q-axis",
+                "internal_default": "[:eq_p, :ψ_kd, :ψq_pp]",
+                "data_type": "Vector{Symbol}"
+            },
+            {
+                "name": "n_states",
+                "comment": "",
+                "internal_default": 3,
+                "data_type": "Int64"
+            },
+            {
+                "name": "internal",
+                "comment": "power system internal reference, do not modify",
+                "data_type": "InfrastructureSystemsInternal",
+                "internal_default": "InfrastructureSystemsInternal()"
+            }
+        ],
+        "supertype": "Machine"
+    },
+    {
         "struct_name": "AndersonFouadMachine",
         "docstring": "Parameters of 6-states synchronous machine: Anderson-Fouad model",
         "fields": [

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2911,7 +2911,7 @@
             },
             {
                 "name": "S1_0",
-                "comment": "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A)",
+                "comment": "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A) -> S(1.2) = B(1.2-A)^2",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
@@ -2921,7 +2921,7 @@
             },
             {
                 "name": "S1_2",
-                "comment": "Saturation factor at 1.2 pu flux: S(1.2) = B(|ψ_pp|-A)",
+                "comment": "Saturation factor at 1.2 pu flux: S(1.2) = B(|ψ_pp|-A)^2 -> S(1.2) = B(1.2-A)^2",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
@@ -3052,7 +3052,7 @@
             },
             {
                 "name": "S1_0",
-                "comment": "Saturation factor at 1 pu flux: S(1.0) = B(eq_p - A)",
+                "comment": "Saturation factor at 1 pu eq_p: S(1.0) = B(eq_p - A) -> S(1.0) = B(1.0 - A)^2",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
@@ -3062,7 +3062,7 @@
             },
             {
                 "name": "S1_2",
-                "comment": "Saturation factor at 1.2 pu flux: S(1.2) = B(eq_p - A)",
+                "comment": "Saturation factor at 1.2 pu eq_p: S(1.2) = B(eq_p - A) -> S(1.2) = B(1.2 - A)^2",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2911,7 +2911,7 @@
             },
             {
                 "name": "S1_0",
-                "comment": "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A)^2 -> S(1.2) = B(1.2-A)^2",
+                "comment": "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A)^2 -> S(1.0) = B(1.0-A)^2",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2911,7 +2911,7 @@
             },
             {
                 "name": "S1_0",
-                "comment": "Saturation factor at 1 pu flux",
+                "comment": "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A)",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
@@ -2921,7 +2921,7 @@
             },
             {
                 "name": "S1_2",
-                "comment": "Saturation factor at 1 pu flux",
+                "comment": "Saturation factor at 1.2 pu flux: S(1.2) = B(|ψ_pp|-A)",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
@@ -3052,7 +3052,7 @@
             },
             {
                 "name": "S1_0",
-                "comment": "Saturation factor at 1 pu flux",
+                "comment": "Saturation factor at 1 pu flux: S(1.0) = B(eq_p - A)",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
@@ -3062,7 +3062,7 @@
             },
             {
                 "name": "S1_2",
-                "comment": "Saturation factor at 1 pu flux",
+                "comment": "Saturation factor at 1.2 pu flux: S(1.2) = B(eq_p - A)",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2911,7 +2911,7 @@
             },
             {
                 "name": "S1_0",
-                "comment": "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A) -> S(1.2) = B(1.2-A)^2",
+                "comment": "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A)^2 -> S(1.2) = B(1.2-A)^2",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
@@ -3052,7 +3052,7 @@
             },
             {
                 "name": "S1_0",
-                "comment": "Saturation factor at 1 pu eq_p: S(1.0) = B(eq_p - A) -> S(1.0) = B(1.0 - A)^2",
+                "comment": "Saturation factor at 1 pu eq_p: S(1.0) = B(eq_p - A)^2 -> S(1.0) = B(1.0 - A)^2",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {
@@ -3062,7 +3062,7 @@
             },
             {
                 "name": "S1_2",
-                "comment": "Saturation factor at 1.2 pu eq_p: S(1.2) = B(eq_p - A) -> S(1.2) = B(1.2 - A)^2",
+                "comment": "Saturation factor at 1.2 pu eq_p: S(1.2) = B(eq_p - A)^2 -> S(1.2) = B(1.2 - A)^2",
                 "null_value": 0,
                 "data_type": "Float64",
                 "valid_range": {

--- a/src/models/generated/GENROU.jl
+++ b/src/models/generated/GENROU.jl
@@ -36,7 +36,7 @@ Parameters of 4-states round-rotor synchronous machine: GENROU model
 - `Xq_p::Float64`: Transient reactance after EMF in q-axis per unit, validation range: (0, nothing)
 - `Xd_pp::Float64`: Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp, validation range: (0, nothing)
 - `Xl::Float64`: Stator leakage reactance, validation range: (0, nothing)
-- `S1_0::Float64`: Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A)^2 -> S(1.2) = B(1.2-A)^2, validation range: (0, nothing)
+- `S1_0::Float64`: Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A)^2 -> S(1.0) = B(1.0-A)^2, validation range: (0, nothing)
 - `S1_2::Float64`: Saturation factor at 1.2 pu flux: S(1.2) = B(|ψ_pp|-A)^2 -> S(1.2) = B(1.2-A)^2, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: The states are:
@@ -70,7 +70,7 @@ mutable struct GENROU <: Machine
     Xd_pp::Float64
     "Stator leakage reactance"
     Xl::Float64
-    "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A)^2 -> S(1.2) = B(1.2-A)^2"
+    "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A)^2 -> S(1.0) = B(1.0-A)^2"
     S1_0::Float64
     "Saturation factor at 1.2 pu flux: S(1.2) = B(|ψ_pp|-A)^2 -> S(1.2) = B(1.2-A)^2"
     S1_2::Float64

--- a/src/models/generated/GENROU.jl
+++ b/src/models/generated/GENROU.jl
@@ -36,8 +36,8 @@ Parameters of 4-states round-rotor synchronous machine: GENROU model
 - `Xq_p::Float64`: Transient reactance after EMF in q-axis per unit, validation range: (0, nothing)
 - `Xd_pp::Float64`: Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp, validation range: (0, nothing)
 - `Xl::Float64`: Stator leakage reactance, validation range: (0, nothing)
-- `S1_0::Float64`: Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A), validation range: (0, nothing)
-- `S1_2::Float64`: Saturation factor at 1.2 pu flux: S(1.2) = B(|ψ_pp|-A), validation range: (0, nothing)
+- `S1_0::Float64`: Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A) -> S(1.2) = B(1.2-A)^2, validation range: (0, nothing)
+- `S1_2::Float64`: Saturation factor at 1.2 pu flux: S(1.2) = B(|ψ_pp|-A)^2 -> S(1.2) = B(1.2-A)^2, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: The states are:
 	eq_p: q-axis generator voltage behind the transient reactance,
@@ -70,9 +70,9 @@ mutable struct GENROU <: Machine
     Xd_pp::Float64
     "Stator leakage reactance"
     Xl::Float64
-    "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A)"
+    "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A) -> S(1.2) = B(1.2-A)^2"
     S1_0::Float64
-    "Saturation factor at 1.2 pu flux: S(1.2) = B(|ψ_pp|-A)"
+    "Saturation factor at 1.2 pu flux: S(1.2) = B(|ψ_pp|-A)^2 -> S(1.2) = B(1.2-A)^2"
     S1_2::Float64
     ext::Dict{String, Any}
     "The states are:

--- a/src/models/generated/GENROU.jl
+++ b/src/models/generated/GENROU.jl
@@ -1,0 +1,185 @@
+#=
+This file is auto-generated. Do not edit.
+=#
+"""
+    mutable struct GENROU <: Machine
+        R::Float64
+        Td0_p::Float64
+        Td0_pp::Float64
+        Tq0_p::Float64
+        Tq0_pp::Float64
+        Xd::Float64
+        Xq::Float64
+        Xd_p::Float64
+        Xq_p::Float64
+        Xd_pp::Float64
+        Xl::Float64
+        S1_0::Float64
+        S1_2::Float64
+        ext::Dict{String, Any}
+        states::Vector{Symbol}
+        n_states::Int64
+        internal::InfrastructureSystemsInternal
+    end
+
+Parameters of 4-states round-rotor synchronous machine: GENROU model
+
+# Arguments
+- `R::Float64`: Armature resistance, validation range: (0, nothing)
+- `Td0_p::Float64`: Time constant of transient d-axis voltage, validation range: (0, nothing)
+- `Td0_pp::Float64`: Time constant of sub-transient d-axis voltage, validation range: (0, nothing)
+- `Tq0_p::Float64`: Time constant of transient q-axis voltage, validation range: (0, nothing)
+- `Tq0_pp::Float64`: Time constant of sub-transient q-axis voltage, validation range: (0, nothing)
+- `Xd::Float64`: Reactance after EMF in d-axis per unit, validation range: (0, nothing)
+- `Xq::Float64`: Reactance after EMF in q-axis per unit, validation range: (0, nothing)
+- `Xd_p::Float64`: Transient reactance after EMF in d-axis per unit, validation range: (0, nothing)
+- `Xq_p::Float64`: Transient reactance after EMF in q-axis per unit, validation range: (0, nothing)
+- `Xd_pp::Float64`: Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp, validation range: (0, nothing)
+- `Xl::Float64`: Stator leakage reactance, validation range: (0, nothing)
+- `S1_0::Float64`: Saturation factor at 1 pu flux, validation range: (0, nothing)
+- `S1_2::Float64`: Saturation factor at 1 pu flux, validation range: (0, nothing)
+- `ext::Dict{String, Any}`
+- `states::Vector{Symbol}`: The states are:
+	eq_p: q-axis generator voltage behind the transient reactance,
+	ed_p: d-axis generator voltage behind the transient reactance,
+	ψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,
+	ψ_kq: flux linkage in the first equivalent damping circuit in the d-axis
+- `n_states::Int64`
+- `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
+"""
+mutable struct GENROU <: Machine
+    "Armature resistance"
+    R::Float64
+    "Time constant of transient d-axis voltage"
+    Td0_p::Float64
+    "Time constant of sub-transient d-axis voltage"
+    Td0_pp::Float64
+    "Time constant of transient q-axis voltage"
+    Tq0_p::Float64
+    "Time constant of sub-transient q-axis voltage"
+    Tq0_pp::Float64
+    "Reactance after EMF in d-axis per unit"
+    Xd::Float64
+    "Reactance after EMF in q-axis per unit"
+    Xq::Float64
+    "Transient reactance after EMF in d-axis per unit"
+    Xd_p::Float64
+    "Transient reactance after EMF in q-axis per unit"
+    Xq_p::Float64
+    "Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp"
+    Xd_pp::Float64
+    "Stator leakage reactance"
+    Xl::Float64
+    "Saturation factor at 1 pu flux"
+    S1_0::Float64
+    "Saturation factor at 1 pu flux"
+    S1_2::Float64
+    ext::Dict{String, Any}
+    "The states are:
+	eq_p: q-axis generator voltage behind the transient reactance,
+	ed_p: d-axis generator voltage behind the transient reactance,
+	ψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,
+	ψ_kq: flux linkage in the first equivalent damping circuit in the d-axis"
+    states::Vector{Symbol}
+    n_states::Int64
+    "power system internal reference, do not modify"
+    internal::InfrastructureSystemsInternal
+end
+
+function GENROU(R, Td0_p, Td0_pp, Tq0_p, Tq0_pp, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xl, S1_0, S1_2, ext=Dict{String, Any}(), )
+    GENROU(R, Td0_p, Td0_pp, Tq0_p, Tq0_pp, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xl, S1_0, S1_2, ext, [:eq_p, :ed_p, :ψ_kd, :ψ_kq], 4, InfrastructureSystemsInternal(), )
+end
+
+function GENROU(; R, Td0_p, Td0_pp, Tq0_p, Tq0_pp, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xl, S1_0, S1_2, ext=Dict{String, Any}(), )
+    GENROU(R, Td0_p, Td0_pp, Tq0_p, Tq0_pp, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xl, S1_0, S1_2, ext, )
+end
+
+# Constructor for demo purposes; non-functional.
+function GENROU(::Nothing)
+    GENROU(;
+        R=0,
+        Td0_p=0,
+        Td0_pp=0,
+        Tq0_p=0,
+        Tq0_pp=0,
+        Xd=0,
+        Xq=0,
+        Xd_p=0,
+        Xq_p=0,
+        Xd_pp=0,
+        Xl=0,
+        S1_0=0,
+        S1_2=0,
+        ext=Dict{String, Any}(),
+    )
+end
+
+"""Get GENROU R."""
+get_R(value::GENROU) = value.R
+"""Get GENROU Td0_p."""
+get_Td0_p(value::GENROU) = value.Td0_p
+"""Get GENROU Td0_pp."""
+get_Td0_pp(value::GENROU) = value.Td0_pp
+"""Get GENROU Tq0_p."""
+get_Tq0_p(value::GENROU) = value.Tq0_p
+"""Get GENROU Tq0_pp."""
+get_Tq0_pp(value::GENROU) = value.Tq0_pp
+"""Get GENROU Xd."""
+get_Xd(value::GENROU) = value.Xd
+"""Get GENROU Xq."""
+get_Xq(value::GENROU) = value.Xq
+"""Get GENROU Xd_p."""
+get_Xd_p(value::GENROU) = value.Xd_p
+"""Get GENROU Xq_p."""
+get_Xq_p(value::GENROU) = value.Xq_p
+"""Get GENROU Xd_pp."""
+get_Xd_pp(value::GENROU) = value.Xd_pp
+"""Get GENROU Xl."""
+get_Xl(value::GENROU) = value.Xl
+"""Get GENROU S1_0."""
+get_S1_0(value::GENROU) = value.S1_0
+"""Get GENROU S1_2."""
+get_S1_2(value::GENROU) = value.S1_2
+"""Get GENROU ext."""
+get_ext(value::GENROU) = value.ext
+"""Get GENROU states."""
+get_states(value::GENROU) = value.states
+"""Get GENROU n_states."""
+get_n_states(value::GENROU) = value.n_states
+"""Get GENROU internal."""
+get_internal(value::GENROU) = value.internal
+
+"""Set GENROU R."""
+set_R!(value::GENROU, val::Float64) = value.R = val
+"""Set GENROU Td0_p."""
+set_Td0_p!(value::GENROU, val::Float64) = value.Td0_p = val
+"""Set GENROU Td0_pp."""
+set_Td0_pp!(value::GENROU, val::Float64) = value.Td0_pp = val
+"""Set GENROU Tq0_p."""
+set_Tq0_p!(value::GENROU, val::Float64) = value.Tq0_p = val
+"""Set GENROU Tq0_pp."""
+set_Tq0_pp!(value::GENROU, val::Float64) = value.Tq0_pp = val
+"""Set GENROU Xd."""
+set_Xd!(value::GENROU, val::Float64) = value.Xd = val
+"""Set GENROU Xq."""
+set_Xq!(value::GENROU, val::Float64) = value.Xq = val
+"""Set GENROU Xd_p."""
+set_Xd_p!(value::GENROU, val::Float64) = value.Xd_p = val
+"""Set GENROU Xq_p."""
+set_Xq_p!(value::GENROU, val::Float64) = value.Xq_p = val
+"""Set GENROU Xd_pp."""
+set_Xd_pp!(value::GENROU, val::Float64) = value.Xd_pp = val
+"""Set GENROU Xl."""
+set_Xl!(value::GENROU, val::Float64) = value.Xl = val
+"""Set GENROU S1_0."""
+set_S1_0!(value::GENROU, val::Float64) = value.S1_0 = val
+"""Set GENROU S1_2."""
+set_S1_2!(value::GENROU, val::Float64) = value.S1_2 = val
+"""Set GENROU ext."""
+set_ext!(value::GENROU, val::Dict{String, Any}) = value.ext = val
+"""Set GENROU states."""
+set_states!(value::GENROU, val::Vector{Symbol}) = value.states = val
+"""Set GENROU n_states."""
+set_n_states!(value::GENROU, val::Int64) = value.n_states = val
+"""Set GENROU internal."""
+set_internal!(value::GENROU, val::InfrastructureSystemsInternal) = value.internal = val

--- a/src/models/generated/GENROU.jl
+++ b/src/models/generated/GENROU.jl
@@ -36,7 +36,7 @@ Parameters of 4-states round-rotor synchronous machine: GENROU model
 - `Xq_p::Float64`: Transient reactance after EMF in q-axis per unit, validation range: (0, nothing)
 - `Xd_pp::Float64`: Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp, validation range: (0, nothing)
 - `Xl::Float64`: Stator leakage reactance, validation range: (0, nothing)
-- `S1_0::Float64`: Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A) -> S(1.2) = B(1.2-A)^2, validation range: (0, nothing)
+- `S1_0::Float64`: Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A)^2 -> S(1.2) = B(1.2-A)^2, validation range: (0, nothing)
 - `S1_2::Float64`: Saturation factor at 1.2 pu flux: S(1.2) = B(|ψ_pp|-A)^2 -> S(1.2) = B(1.2-A)^2, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: The states are:
@@ -70,7 +70,7 @@ mutable struct GENROU <: Machine
     Xd_pp::Float64
     "Stator leakage reactance"
     Xl::Float64
-    "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A) -> S(1.2) = B(1.2-A)^2"
+    "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A)^2 -> S(1.2) = B(1.2-A)^2"
     S1_0::Float64
     "Saturation factor at 1.2 pu flux: S(1.2) = B(|ψ_pp|-A)^2 -> S(1.2) = B(1.2-A)^2"
     S1_2::Float64

--- a/src/models/generated/GENROU.jl
+++ b/src/models/generated/GENROU.jl
@@ -36,8 +36,8 @@ Parameters of 4-states round-rotor synchronous machine: GENROU model
 - `Xq_p::Float64`: Transient reactance after EMF in q-axis per unit, validation range: (0, nothing)
 - `Xd_pp::Float64`: Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp, validation range: (0, nothing)
 - `Xl::Float64`: Stator leakage reactance, validation range: (0, nothing)
-- `S1_0::Float64`: Saturation factor at 1 pu flux, validation range: (0, nothing)
-- `S1_2::Float64`: Saturation factor at 1 pu flux, validation range: (0, nothing)
+- `S1_0::Float64`: Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A), validation range: (0, nothing)
+- `S1_2::Float64`: Saturation factor at 1.2 pu flux: S(1.2) = B(|ψ_pp|-A), validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: The states are:
 	eq_p: q-axis generator voltage behind the transient reactance,
@@ -70,9 +70,9 @@ mutable struct GENROU <: Machine
     Xd_pp::Float64
     "Stator leakage reactance"
     Xl::Float64
-    "Saturation factor at 1 pu flux"
+    "Saturation factor at 1 pu flux: S(1.0) = B(|ψ_pp|-A)"
     S1_0::Float64
-    "Saturation factor at 1 pu flux"
+    "Saturation factor at 1.2 pu flux: S(1.2) = B(|ψ_pp|-A)"
     S1_2::Float64
     ext::Dict{String, Any}
     "The states are:

--- a/src/models/generated/GENSAL.jl
+++ b/src/models/generated/GENSAL.jl
@@ -1,0 +1,165 @@
+#=
+This file is auto-generated. Do not edit.
+=#
+"""
+    mutable struct GENSAL <: Machine
+        R::Float64
+        Td0_p::Float64
+        Td0_pp::Float64
+        Tq0_pp::Float64
+        Xd::Float64
+        Xq::Float64
+        Xd_p::Float64
+        Xd_pp::Float64
+        Xl::Float64
+        S1_0::Float64
+        S1_2::Float64
+        ext::Dict{String, Any}
+        states::Vector{Symbol}
+        n_states::Int64
+        internal::InfrastructureSystemsInternal
+    end
+
+Parameters of 3-states salient-pole synchronous machine: GENSAL model
+
+# Arguments
+- `R::Float64`: Armature resistance, validation range: (0, nothing)
+- `Td0_p::Float64`: Time constant of transient d-axis voltage, validation range: (0, nothing)
+- `Td0_pp::Float64`: Time constant of sub-transient d-axis voltage, validation range: (0, nothing)
+- `Tq0_pp::Float64`: Time constant of sub-transient q-axis voltage, validation range: (0, nothing)
+- `Xd::Float64`: Reactance after EMF in d-axis per unit, validation range: (0, nothing)
+- `Xq::Float64`: Reactance after EMF in q-axis per unit, validation range: (0, nothing)
+- `Xd_p::Float64`: Transient reactance after EMF in d-axis per unit, validation range: (0, nothing)
+- `Xd_pp::Float64`: Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp, validation range: (0, nothing)
+- `Xl::Float64`: Stator leakage reactance, validation range: (0, nothing)
+- `S1_0::Float64`: Saturation factor at 1 pu flux, validation range: (0, nothing)
+- `S1_2::Float64`: Saturation factor at 1 pu flux, validation range: (0, nothing)
+- `ext::Dict{String, Any}`
+- `states::Vector{Symbol}`: The states are:
+	eq_p: q-axis generator voltage behind the transient reactance,
+	ψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,
+	ψq_pp: phasonf of the subtransient flux linkage in the q-axis
+- `n_states::Int64`
+- `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
+"""
+mutable struct GENSAL <: Machine
+    "Armature resistance"
+    R::Float64
+    "Time constant of transient d-axis voltage"
+    Td0_p::Float64
+    "Time constant of sub-transient d-axis voltage"
+    Td0_pp::Float64
+    "Time constant of sub-transient q-axis voltage"
+    Tq0_pp::Float64
+    "Reactance after EMF in d-axis per unit"
+    Xd::Float64
+    "Reactance after EMF in q-axis per unit"
+    Xq::Float64
+    "Transient reactance after EMF in d-axis per unit"
+    Xd_p::Float64
+    "Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp"
+    Xd_pp::Float64
+    "Stator leakage reactance"
+    Xl::Float64
+    "Saturation factor at 1 pu flux"
+    S1_0::Float64
+    "Saturation factor at 1 pu flux"
+    S1_2::Float64
+    ext::Dict{String, Any}
+    "The states are:
+	eq_p: q-axis generator voltage behind the transient reactance,
+	ψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,
+	ψq_pp: phasonf of the subtransient flux linkage in the q-axis"
+    states::Vector{Symbol}
+    n_states::Int64
+    "power system internal reference, do not modify"
+    internal::InfrastructureSystemsInternal
+end
+
+function GENSAL(R, Td0_p, Td0_pp, Tq0_pp, Xd, Xq, Xd_p, Xd_pp, Xl, S1_0, S1_2, ext=Dict{String, Any}(), )
+    GENSAL(R, Td0_p, Td0_pp, Tq0_pp, Xd, Xq, Xd_p, Xd_pp, Xl, S1_0, S1_2, ext, [:eq_p, :ψ_kd, :ψq_pp], 3, InfrastructureSystemsInternal(), )
+end
+
+function GENSAL(; R, Td0_p, Td0_pp, Tq0_pp, Xd, Xq, Xd_p, Xd_pp, Xl, S1_0, S1_2, ext=Dict{String, Any}(), )
+    GENSAL(R, Td0_p, Td0_pp, Tq0_pp, Xd, Xq, Xd_p, Xd_pp, Xl, S1_0, S1_2, ext, )
+end
+
+# Constructor for demo purposes; non-functional.
+function GENSAL(::Nothing)
+    GENSAL(;
+        R=0,
+        Td0_p=0,
+        Td0_pp=0,
+        Tq0_pp=0,
+        Xd=0,
+        Xq=0,
+        Xd_p=0,
+        Xd_pp=0,
+        Xl=0,
+        S1_0=0,
+        S1_2=0,
+        ext=Dict{String, Any}(),
+    )
+end
+
+"""Get GENSAL R."""
+get_R(value::GENSAL) = value.R
+"""Get GENSAL Td0_p."""
+get_Td0_p(value::GENSAL) = value.Td0_p
+"""Get GENSAL Td0_pp."""
+get_Td0_pp(value::GENSAL) = value.Td0_pp
+"""Get GENSAL Tq0_pp."""
+get_Tq0_pp(value::GENSAL) = value.Tq0_pp
+"""Get GENSAL Xd."""
+get_Xd(value::GENSAL) = value.Xd
+"""Get GENSAL Xq."""
+get_Xq(value::GENSAL) = value.Xq
+"""Get GENSAL Xd_p."""
+get_Xd_p(value::GENSAL) = value.Xd_p
+"""Get GENSAL Xd_pp."""
+get_Xd_pp(value::GENSAL) = value.Xd_pp
+"""Get GENSAL Xl."""
+get_Xl(value::GENSAL) = value.Xl
+"""Get GENSAL S1_0."""
+get_S1_0(value::GENSAL) = value.S1_0
+"""Get GENSAL S1_2."""
+get_S1_2(value::GENSAL) = value.S1_2
+"""Get GENSAL ext."""
+get_ext(value::GENSAL) = value.ext
+"""Get GENSAL states."""
+get_states(value::GENSAL) = value.states
+"""Get GENSAL n_states."""
+get_n_states(value::GENSAL) = value.n_states
+"""Get GENSAL internal."""
+get_internal(value::GENSAL) = value.internal
+
+"""Set GENSAL R."""
+set_R!(value::GENSAL, val::Float64) = value.R = val
+"""Set GENSAL Td0_p."""
+set_Td0_p!(value::GENSAL, val::Float64) = value.Td0_p = val
+"""Set GENSAL Td0_pp."""
+set_Td0_pp!(value::GENSAL, val::Float64) = value.Td0_pp = val
+"""Set GENSAL Tq0_pp."""
+set_Tq0_pp!(value::GENSAL, val::Float64) = value.Tq0_pp = val
+"""Set GENSAL Xd."""
+set_Xd!(value::GENSAL, val::Float64) = value.Xd = val
+"""Set GENSAL Xq."""
+set_Xq!(value::GENSAL, val::Float64) = value.Xq = val
+"""Set GENSAL Xd_p."""
+set_Xd_p!(value::GENSAL, val::Float64) = value.Xd_p = val
+"""Set GENSAL Xd_pp."""
+set_Xd_pp!(value::GENSAL, val::Float64) = value.Xd_pp = val
+"""Set GENSAL Xl."""
+set_Xl!(value::GENSAL, val::Float64) = value.Xl = val
+"""Set GENSAL S1_0."""
+set_S1_0!(value::GENSAL, val::Float64) = value.S1_0 = val
+"""Set GENSAL S1_2."""
+set_S1_2!(value::GENSAL, val::Float64) = value.S1_2 = val
+"""Set GENSAL ext."""
+set_ext!(value::GENSAL, val::Dict{String, Any}) = value.ext = val
+"""Set GENSAL states."""
+set_states!(value::GENSAL, val::Vector{Symbol}) = value.states = val
+"""Set GENSAL n_states."""
+set_n_states!(value::GENSAL, val::Int64) = value.n_states = val
+"""Set GENSAL internal."""
+set_internal!(value::GENSAL, val::InfrastructureSystemsInternal) = value.internal = val

--- a/src/models/generated/GENSAL.jl
+++ b/src/models/generated/GENSAL.jl
@@ -32,8 +32,8 @@ Parameters of 3-states salient-pole synchronous machine: GENSAL model
 - `Xd_p::Float64`: Transient reactance after EMF in d-axis per unit, validation range: (0, nothing)
 - `Xd_pp::Float64`: Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp, validation range: (0, nothing)
 - `Xl::Float64`: Stator leakage reactance, validation range: (0, nothing)
-- `S1_0::Float64`: Saturation factor at 1 pu flux: S(1.0) = B(eq_p - A), validation range: (0, nothing)
-- `S1_2::Float64`: Saturation factor at 1.2 pu flux: S(1.2) = B(eq_p - A), validation range: (0, nothing)
+- `S1_0::Float64`: Saturation factor at 1 pu eq_p: S(1.0) = B(eq_p - A) -> S(1.0) = B(1.0 - A)^2, validation range: (0, nothing)
+- `S1_2::Float64`: Saturation factor at 1.2 pu eq_p: S(1.2) = B(eq_p - A) -> S(1.2) = B(1.2 - A)^2, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: The states are:
 	eq_p: q-axis generator voltage behind the transient reactance,
@@ -61,9 +61,9 @@ mutable struct GENSAL <: Machine
     Xd_pp::Float64
     "Stator leakage reactance"
     Xl::Float64
-    "Saturation factor at 1 pu flux: S(1.0) = B(eq_p - A)"
+    "Saturation factor at 1 pu eq_p: S(1.0) = B(eq_p - A) -> S(1.0) = B(1.0 - A)^2"
     S1_0::Float64
-    "Saturation factor at 1.2 pu flux: S(1.2) = B(eq_p - A)"
+    "Saturation factor at 1.2 pu eq_p: S(1.2) = B(eq_p - A) -> S(1.2) = B(1.2 - A)^2"
     S1_2::Float64
     ext::Dict{String, Any}
     "The states are:

--- a/src/models/generated/GENSAL.jl
+++ b/src/models/generated/GENSAL.jl
@@ -32,8 +32,8 @@ Parameters of 3-states salient-pole synchronous machine: GENSAL model
 - `Xd_p::Float64`: Transient reactance after EMF in d-axis per unit, validation range: (0, nothing)
 - `Xd_pp::Float64`: Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp, validation range: (0, nothing)
 - `Xl::Float64`: Stator leakage reactance, validation range: (0, nothing)
-- `S1_0::Float64`: Saturation factor at 1 pu eq_p: S(1.0) = B(eq_p - A) -> S(1.0) = B(1.0 - A)^2, validation range: (0, nothing)
-- `S1_2::Float64`: Saturation factor at 1.2 pu eq_p: S(1.2) = B(eq_p - A) -> S(1.2) = B(1.2 - A)^2, validation range: (0, nothing)
+- `S1_0::Float64`: Saturation factor at 1 pu eq_p: S(1.0) = B(eq_p - A)^2 -> S(1.0) = B(1.0 - A)^2, validation range: (0, nothing)
+- `S1_2::Float64`: Saturation factor at 1.2 pu eq_p: S(1.2) = B(eq_p - A)^2 -> S(1.2) = B(1.2 - A)^2, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: The states are:
 	eq_p: q-axis generator voltage behind the transient reactance,
@@ -61,9 +61,9 @@ mutable struct GENSAL <: Machine
     Xd_pp::Float64
     "Stator leakage reactance"
     Xl::Float64
-    "Saturation factor at 1 pu eq_p: S(1.0) = B(eq_p - A) -> S(1.0) = B(1.0 - A)^2"
+    "Saturation factor at 1 pu eq_p: S(1.0) = B(eq_p - A)^2 -> S(1.0) = B(1.0 - A)^2"
     S1_0::Float64
-    "Saturation factor at 1.2 pu eq_p: S(1.2) = B(eq_p - A) -> S(1.2) = B(1.2 - A)^2"
+    "Saturation factor at 1.2 pu eq_p: S(1.2) = B(eq_p - A)^2 -> S(1.2) = B(1.2 - A)^2"
     S1_2::Float64
     ext::Dict{String, Any}
     "The states are:

--- a/src/models/generated/GENSAL.jl
+++ b/src/models/generated/GENSAL.jl
@@ -32,8 +32,8 @@ Parameters of 3-states salient-pole synchronous machine: GENSAL model
 - `Xd_p::Float64`: Transient reactance after EMF in d-axis per unit, validation range: (0, nothing)
 - `Xd_pp::Float64`: Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp, validation range: (0, nothing)
 - `Xl::Float64`: Stator leakage reactance, validation range: (0, nothing)
-- `S1_0::Float64`: Saturation factor at 1 pu flux, validation range: (0, nothing)
-- `S1_2::Float64`: Saturation factor at 1 pu flux, validation range: (0, nothing)
+- `S1_0::Float64`: Saturation factor at 1 pu flux: S(1.0) = B(eq_p - A), validation range: (0, nothing)
+- `S1_2::Float64`: Saturation factor at 1.2 pu flux: S(1.2) = B(eq_p - A), validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: The states are:
 	eq_p: q-axis generator voltage behind the transient reactance,
@@ -61,9 +61,9 @@ mutable struct GENSAL <: Machine
     Xd_pp::Float64
     "Stator leakage reactance"
     Xl::Float64
-    "Saturation factor at 1 pu flux"
+    "Saturation factor at 1 pu flux: S(1.0) = B(eq_p - A)"
     S1_0::Float64
-    "Saturation factor at 1 pu flux"
+    "Saturation factor at 1.2 pu flux: S(1.2) = B(eq_p - A)"
     S1_2::Float64
     ext::Dict{String, Any}
     "The states are:

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -30,6 +30,8 @@ include("AVRSimple.jl")
 include("AVRTypeI.jl")
 include("AVRTypeII.jl")
 include("BaseMachine.jl")
+include("GENROU.jl")
+include("GENSAL.jl")
 include("AndersonFouadMachine.jl")
 include("FullMachine.jl")
 include("MarconatoMachine.jl")
@@ -98,6 +100,8 @@ export get_R
 export get_R_1d
 export get_R_1q
 export get_R_f
+export get_S1_0
+export get_S1_2
 export get_T1
 export get_T2
 export get_T3
@@ -123,6 +127,7 @@ export get_X_th
 export get_Xd
 export get_Xd_p
 export get_Xd_pp
+export get_Xl
 export get_Xq
 export get_Xq_p
 export get_Xq_pp
@@ -277,6 +282,8 @@ export set_R!
 export set_R_1d!
 export set_R_1q!
 export set_R_f!
+export set_S1_0!
+export set_S1_2!
 export set_T1!
 export set_T2!
 export set_T3!
@@ -302,6 +309,7 @@ export set_X_th!
 export set_Xd!
 export set_Xd_p!
 export set_Xd_pp!
+export set_Xl!
 export set_Xq!
 export set_Xq_p!
 export set_Xq_pp!


### PR DESCRIPTION
The following PR includes both GENROU and GENSAL data structs used in PSS/E. The main differences with the data provided in the Reference Manual of PSS/E are:
- Machine models does not include the angle and rotor speed. Those are computed in the shaft.
- The armature resistance is not provided as a parameter of the GENROU/SAL models in the reference manual. Model descriptions in Paszek book: Synchronous Generators and Excitation Systems Operating in a Power System include the armature resistance, so for completeness we decided to include it. We can default it to zero already in the struct definition or when doing the parsing. We are not sure how PSS/E provides the armature resistance (or if it's actually modeled).

We decided to include states doc-strings. This is a feature in progress, and eventually will be added to all dynamic structures.