### PR TITLE
Add Salient Pole and Round Rotor machine dynamic models

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -74,6 +74,8 @@ export AVRTypeII
 #Machine Exports
 export Machine
 export BaseMachine
+export RoundRotorQuadratic
+export SalientPoleQuadratic
 export OneDOneQMachine
 export MarconatoMachine
 export SimpleMarconatoMachine

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2797,6 +2797,294 @@
       "supertype": "Machine"
     },
     {
+        "struct_name": "RoundRotorQuadratic",
+        "docstring": "Parameters of 4-states round-rotor synchronous machine with quadratic saturation:\nIEEE Std 1110 §5.3.2 (Model 2.2). GENROU model in PSSE and PSLF.",
+        "fields": [
+            {
+                "name": "R",
+                "comment": "Armature resistance",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Td0_p",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of transient d-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Td0_pp",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of sub-transient d-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Tq0_p",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of transient q-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Tq0_pp",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of sub-transient q-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xd",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Reactance after EMF in d-axis per unit",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xq",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Reactance after EMF in q-axis per unit",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xd_p",
+                "comment": "Transient reactance after EMF in d-axis per unit",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xq_p",
+                "comment": "Transient reactance after EMF in q-axis per unit",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xd_pp",
+                "comment": "Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xl",
+                "comment": "Stator leakage reactance",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Se",
+                "comment": "Saturation factor at 1 and 1.2 pu flux: S(1.0) = B(|ψ_pp|-A)^2",
+                "null_value": "(0.0, 0.0)",
+                "data_type": "Tuple{Float64, Float64}"
+            },
+            {
+                "name": "ext",
+                "data_type": "Dict{String, Any}",
+                "null_value": "Dict{String, Any}()",
+                "default": "Dict{String, Any}()"
+            },
+            {
+                "name": "saturation_coeffs",
+                "comment": "Saturation coefficients of quadratic saturation: (A, B): Se = B(|ψ_pp|-A)^2",
+                "null_value": "(0.0, 0.0)",
+                "data_type": "Tuple{Float64, Float64}",
+                "internal_default": "get_quadratic_saturation(Se)"
+            },
+            {
+                "name": "states",
+                "comment": "The states are:\n\teq_p: q-axis generator voltage behind the transient reactance,\n\ted_p: d-axis generator voltage behind the transient reactance,\n\tψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,\n\tψ_kq: flux linkage in the first equivalent damping circuit in the d-axis",
+                "internal_default": "[:eq_p, :ed_p, :ψ_kd, :ψ_kq]",
+                "data_type": "Vector{Symbol}"
+            },
+            {
+                "name": "n_states",
+                "comment": "",
+                "internal_default": 4,
+                "data_type": "Int64"
+            },
+            {
+                "name": "internal",
+                "comment": "power system internal reference, do not modify",
+                "data_type": "InfrastructureSystemsInternal",
+                "internal_default": "InfrastructureSystemsInternal()"
+            }
+        ],
+        "supertype": "Machine"
+    },
+    {
+        "struct_name": "SalientPoleQuadratic",
+        "docstring": "Parameters of 3-states salient-pole synchronous machine with quadratic saturation:\nIEEE Std 1110 §5.3.1 (Model 2.1). GENSAL model in PSSE and PSLF.",
+        "fields": [
+            {
+                "name": "R",
+                "comment": "Armature resistance",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Td0_p",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of transient d-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Td0_pp",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of sub-transient d-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Tq0_pp",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Time constant of sub-transient q-axis voltage",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xd",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Reactance after EMF in d-axis per unit",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xq",
+                "data_type": "Float64",
+                "null_value": 0,
+                "comment": "Reactance after EMF in q-axis per unit",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xd_p",
+                "comment": "Transient reactance after EMF in d-axis per unit",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xd_pp",
+                "comment": "Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Xl",
+                "comment": "Stator leakage reactance",
+                "null_value": 0,
+                "data_type": "Float64",
+                "valid_range": {
+                    "min": 0,
+                    "max": null
+                }
+            },
+            {
+                "name": "Se",
+                "comment": "Saturation factor at 1 and 1.2 pu flux: Se(eq_p) = B(eq_p-A)^2",
+                "null_value": "(0.0, 0.0)",
+                "data_type": "Tuple{Float64, Float64}"
+            },
+            {
+                "name": "ext",
+                "data_type": "Dict{String, Any}",
+                "null_value": "Dict{String, Any}()",
+                "default": "Dict{String, Any}()"
+            },
+            {
+                "name": "saturation_coeffs",
+                "comment": "Saturation coefficients of quadratic saturation: (A, B): Se = B(eq_p-A)^2",
+                "null_value": "(0.0, 0.0)",
+                "data_type": "Tuple{Float64, Float64}",
+                "internal_default": "get_quadratic_saturation(Se)"
+            },
+            {
+                "name": "states",
+                "comment": "The states are:\n\teq_p: q-axis generator voltage behind the transient reactance,\n\tψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,\n\tψq_pp: phasonf of the subtransient flux linkage in the q-axis",
+                "internal_default": "[:eq_p, :ψ_kd, :ψq_pp]",
+                "data_type": "Vector{Symbol}"
+            },
+            {
+                "name": "n_states",
+                "comment": "",
+                "internal_default": 3,
+                "data_type": "Int64"
+            },
+            {
+                "name": "internal",
+                "comment": "power system internal reference, do not modify",
+                "data_type": "InfrastructureSystemsInternal",
+                "internal_default": "InfrastructureSystemsInternal()"
+            }
+        ],
+        "supertype": "Machine"
+    },
+    {
       "struct_name": "AndersonFouadMachine",
       "docstring": "Parameters of 6-states synchronous machine: Anderson-Fouad model",
       "fields": [

--- a/src/models/dynamic_generator_components.jl
+++ b/src/models/dynamic_generator_components.jl
@@ -4,3 +4,32 @@ abstract type Machine <: DynamicGeneratorComponent end
 abstract type PSS <: DynamicGeneratorComponent end
 abstract type Shaft <: DynamicGeneratorComponent end
 abstract type TurbineGov <: DynamicGeneratorComponent end
+
+"""
+Obtain coefficients (A, B) of the function Se = B(x - A)^2 for
+Se(1.2) = B(1.2 - A)^2 and Se(1.0) = B(1.2 - A)^2 as:
+Se(1.0) = Se(1.2)/(1.2 - A)^2 * (1.0 - A)^2 that yields
+(1.2 - A)^2 Se(1.0) = Se(1.2) * (1.0 - A)^2 or expanding:
+(Se(1.2) - Se(1.0)) A^2 + (2.4 Se(1.0) - 2 Se(1.2)) A + (Se(1.2) - 1.44 Se(1.0)) = 0
+and uses the negative solution of the quadratic equation 
+"""
+function get_quadratic_saturation(Se::Tuple{Float64, Float64})
+    if Se[1] == 0.0 && Se[2] == 0.0
+        return (0.0, 0.0)
+    end
+    if Se[2] <= Se[1]
+        print("Se(1.2) <= Se(1.0). Ignoring saturation")
+        return (0.0, 0.0)
+    end
+    A =
+        (1.0 / (2.0 * (Se[2] - Se[1]))) * (
+            2 * Se[2] - 2.4 * Se[1] - sqrt(
+                (2.4 * Se[1] - 2.0 * Se[2])^2 -
+                4.0 * (Se[2] - 1.44 * Se[1]) * (Se[2] - Se[1]),
+            )
+        )
+    B = Se[2] / (1.2 - A)^2
+
+    @assert abs(B - Se[1] / (1.0 - A)^2) <= 1e-6
+    return (A, B)
+end

--- a/src/models/dynamic_generator_components.jl
+++ b/src/models/dynamic_generator_components.jl
@@ -7,7 +7,7 @@ abstract type TurbineGov <: DynamicGeneratorComponent end
 
 """
 Obtain coefficients (A, B) of the function Se = B(x - A)^2 for
-Se(1.2) = B(1.2 - A)^2 and Se(1.0) = B(1.2 - A)^2 as:
+Se(1.2) = B(1.2 - A)^2 and Se(1.0) = B(1.0 - A)^2 as:
 Se(1.0) = Se(1.2)/(1.2 - A)^2 * (1.0 - A)^2 that yields
 (1.2 - A)^2 Se(1.0) = Se(1.2) * (1.0 - A)^2 or expanding:
 (Se(1.2) - Se(1.0)) A^2 + (2.4 Se(1.0) - 2 Se(1.2)) A + (Se(1.2) - 1.44 Se(1.0)) = 0
@@ -18,8 +18,7 @@ function get_quadratic_saturation(Se::Tuple{Float64, Float64})
         return (0.0, 0.0)
     end
     if Se[2] <= Se[1]
-        print("Se(1.2) <= Se(1.0). Ignoring saturation")
-        return (0.0, 0.0)
+        throw(InfrastructureSystems.ConflictingInputsError("Se(1.2) <= Se(1.0). Saturation data is inconsistent."))
     end
     A =
         (1.0 / (2.0 * (Se[2] - Se[1]))) * (

--- a/src/models/dynamic_generator_components.jl
+++ b/src/models/dynamic_generator_components.jl
@@ -18,7 +18,7 @@ function get_quadratic_saturation(Se::Tuple{Float64, Float64})
         return (0.0, 0.0)
     end
     if Se[2] <= Se[1]
-        throw(InfrastructureSystems.ConflictingInputsError("Se(1.2) <= Se(1.0). Saturation data is inconsistent."))
+        throw(IS.ConflictingInputsError("Se(1.2) <= Se(1.0). Saturation data is inconsistent."))
     end
     A =
         (1.0 / (2.0 * (Se[2] - Se[1]))) * (

--- a/src/models/generated/RoundRotorQuadratic.jl
+++ b/src/models/generated/RoundRotorQuadratic.jl
@@ -1,0 +1,185 @@
+#=
+This file is auto-generated. Do not edit.
+=#
+"""
+    mutable struct RoundRotorQuadratic <: Machine
+        R::Float64
+        Td0_p::Float64
+        Td0_pp::Float64
+        Tq0_p::Float64
+        Tq0_pp::Float64
+        Xd::Float64
+        Xq::Float64
+        Xd_p::Float64
+        Xq_p::Float64
+        Xd_pp::Float64
+        Xl::Float64
+        Se::Tuple{Float64, Float64}
+        ext::Dict{String, Any}
+        saturation_coeffs::Tuple{Float64, Float64}
+        states::Vector{Symbol}
+        n_states::Int64
+        internal::InfrastructureSystemsInternal
+    end
+
+Parameters of 4-states round-rotor synchronous machine with quadratic saturation:
+IEEE Std 1110 §5.3.2 (Model 2.2). GENROU model in PSSE and PSLF.
+
+# Arguments
+- `R::Float64`: Armature resistance, validation range: (0, nothing)
+- `Td0_p::Float64`: Time constant of transient d-axis voltage, validation range: (0, nothing)
+- `Td0_pp::Float64`: Time constant of sub-transient d-axis voltage, validation range: (0, nothing)
+- `Tq0_p::Float64`: Time constant of transient q-axis voltage, validation range: (0, nothing)
+- `Tq0_pp::Float64`: Time constant of sub-transient q-axis voltage, validation range: (0, nothing)
+- `Xd::Float64`: Reactance after EMF in d-axis per unit, validation range: (0, nothing)
+- `Xq::Float64`: Reactance after EMF in q-axis per unit, validation range: (0, nothing)
+- `Xd_p::Float64`: Transient reactance after EMF in d-axis per unit, validation range: (0, nothing)
+- `Xq_p::Float64`: Transient reactance after EMF in q-axis per unit, validation range: (0, nothing)
+- `Xd_pp::Float64`: Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp, validation range: (0, nothing)
+- `Xl::Float64`: Stator leakage reactance, validation range: (0, nothing)
+- `Se::Tuple{Float64, Float64}`: Saturation factor at 1 and 1.2 pu flux: S(1.0) = B(|ψ_pp|-A)^2
+- `ext::Dict{String, Any}`
+- `saturation_coeffs::Tuple{Float64, Float64}`: Saturation coefficients of quadratic saturation: (A, B): Se = B(|ψ_pp|-A)^2
+- `states::Vector{Symbol}`: The states are:
+	eq_p: q-axis generator voltage behind the transient reactance,
+	ed_p: d-axis generator voltage behind the transient reactance,
+	ψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,
+	ψ_kq: flux linkage in the first equivalent damping circuit in the d-axis
+- `n_states::Int64`
+- `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
+"""
+mutable struct RoundRotorQuadratic <: Machine
+    "Armature resistance"
+    R::Float64
+    "Time constant of transient d-axis voltage"
+    Td0_p::Float64
+    "Time constant of sub-transient d-axis voltage"
+    Td0_pp::Float64
+    "Time constant of transient q-axis voltage"
+    Tq0_p::Float64
+    "Time constant of sub-transient q-axis voltage"
+    Tq0_pp::Float64
+    "Reactance after EMF in d-axis per unit"
+    Xd::Float64
+    "Reactance after EMF in q-axis per unit"
+    Xq::Float64
+    "Transient reactance after EMF in d-axis per unit"
+    Xd_p::Float64
+    "Transient reactance after EMF in q-axis per unit"
+    Xq_p::Float64
+    "Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp"
+    Xd_pp::Float64
+    "Stator leakage reactance"
+    Xl::Float64
+    "Saturation factor at 1 and 1.2 pu flux: S(1.0) = B(|ψ_pp|-A)^2"
+    Se::Tuple{Float64, Float64}
+    ext::Dict{String, Any}
+    "Saturation coefficients of quadratic saturation: (A, B): Se = B(|ψ_pp|-A)^2"
+    saturation_coeffs::Tuple{Float64, Float64}
+    "The states are:
+	eq_p: q-axis generator voltage behind the transient reactance,
+	ed_p: d-axis generator voltage behind the transient reactance,
+	ψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,
+	ψ_kq: flux linkage in the first equivalent damping circuit in the d-axis"
+    states::Vector{Symbol}
+    n_states::Int64
+    "power system internal reference, do not modify"
+    internal::InfrastructureSystemsInternal
+end
+
+function RoundRotorQuadratic(R, Td0_p, Td0_pp, Tq0_p, Tq0_pp, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xl, Se, ext=Dict{String, Any}(), )
+    RoundRotorQuadratic(R, Td0_p, Td0_pp, Tq0_p, Tq0_pp, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xl, Se, ext, get_quadratic_saturation(Se), [:eq_p, :ed_p, :ψ_kd, :ψ_kq], 4, InfrastructureSystemsInternal(), )
+end
+
+function RoundRotorQuadratic(; R, Td0_p, Td0_pp, Tq0_p, Tq0_pp, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xl, Se, ext=Dict{String, Any}(), )
+    RoundRotorQuadratic(R, Td0_p, Td0_pp, Tq0_p, Tq0_pp, Xd, Xq, Xd_p, Xq_p, Xd_pp, Xl, Se, ext, )
+end
+
+# Constructor for demo purposes; non-functional.
+function RoundRotorQuadratic(::Nothing)
+    RoundRotorQuadratic(;
+        R=0,
+        Td0_p=0,
+        Td0_pp=0,
+        Tq0_p=0,
+        Tq0_pp=0,
+        Xd=0,
+        Xq=0,
+        Xd_p=0,
+        Xq_p=0,
+        Xd_pp=0,
+        Xl=0,
+        Se=(0.0, 0.0),
+        ext=Dict{String, Any}(),
+    )
+end
+
+"""Get RoundRotorQuadratic R."""
+get_R(value::RoundRotorQuadratic) = value.R
+"""Get RoundRotorQuadratic Td0_p."""
+get_Td0_p(value::RoundRotorQuadratic) = value.Td0_p
+"""Get RoundRotorQuadratic Td0_pp."""
+get_Td0_pp(value::RoundRotorQuadratic) = value.Td0_pp
+"""Get RoundRotorQuadratic Tq0_p."""
+get_Tq0_p(value::RoundRotorQuadratic) = value.Tq0_p
+"""Get RoundRotorQuadratic Tq0_pp."""
+get_Tq0_pp(value::RoundRotorQuadratic) = value.Tq0_pp
+"""Get RoundRotorQuadratic Xd."""
+get_Xd(value::RoundRotorQuadratic) = value.Xd
+"""Get RoundRotorQuadratic Xq."""
+get_Xq(value::RoundRotorQuadratic) = value.Xq
+"""Get RoundRotorQuadratic Xd_p."""
+get_Xd_p(value::RoundRotorQuadratic) = value.Xd_p
+"""Get RoundRotorQuadratic Xq_p."""
+get_Xq_p(value::RoundRotorQuadratic) = value.Xq_p
+"""Get RoundRotorQuadratic Xd_pp."""
+get_Xd_pp(value::RoundRotorQuadratic) = value.Xd_pp
+"""Get RoundRotorQuadratic Xl."""
+get_Xl(value::RoundRotorQuadratic) = value.Xl
+"""Get RoundRotorQuadratic Se."""
+get_Se(value::RoundRotorQuadratic) = value.Se
+"""Get RoundRotorQuadratic ext."""
+get_ext(value::RoundRotorQuadratic) = value.ext
+"""Get RoundRotorQuadratic saturation_coeffs."""
+get_saturation_coeffs(value::RoundRotorQuadratic) = value.saturation_coeffs
+"""Get RoundRotorQuadratic states."""
+get_states(value::RoundRotorQuadratic) = value.states
+"""Get RoundRotorQuadratic n_states."""
+get_n_states(value::RoundRotorQuadratic) = value.n_states
+"""Get RoundRotorQuadratic internal."""
+get_internal(value::RoundRotorQuadratic) = value.internal
+
+"""Set RoundRotorQuadratic R."""
+set_R!(value::RoundRotorQuadratic, val::Float64) = value.R = val
+"""Set RoundRotorQuadratic Td0_p."""
+set_Td0_p!(value::RoundRotorQuadratic, val::Float64) = value.Td0_p = val
+"""Set RoundRotorQuadratic Td0_pp."""
+set_Td0_pp!(value::RoundRotorQuadratic, val::Float64) = value.Td0_pp = val
+"""Set RoundRotorQuadratic Tq0_p."""
+set_Tq0_p!(value::RoundRotorQuadratic, val::Float64) = value.Tq0_p = val
+"""Set RoundRotorQuadratic Tq0_pp."""
+set_Tq0_pp!(value::RoundRotorQuadratic, val::Float64) = value.Tq0_pp = val
+"""Set RoundRotorQuadratic Xd."""
+set_Xd!(value::RoundRotorQuadratic, val::Float64) = value.Xd = val
+"""Set RoundRotorQuadratic Xq."""
+set_Xq!(value::RoundRotorQuadratic, val::Float64) = value.Xq = val
+"""Set RoundRotorQuadratic Xd_p."""
+set_Xd_p!(value::RoundRotorQuadratic, val::Float64) = value.Xd_p = val
+"""Set RoundRotorQuadratic Xq_p."""
+set_Xq_p!(value::RoundRotorQuadratic, val::Float64) = value.Xq_p = val
+"""Set RoundRotorQuadratic Xd_pp."""
+set_Xd_pp!(value::RoundRotorQuadratic, val::Float64) = value.Xd_pp = val
+"""Set RoundRotorQuadratic Xl."""
+set_Xl!(value::RoundRotorQuadratic, val::Float64) = value.Xl = val
+"""Set RoundRotorQuadratic Se."""
+set_Se!(value::RoundRotorQuadratic, val::Tuple{Float64, Float64}) = value.Se = val
+"""Set RoundRotorQuadratic ext."""
+set_ext!(value::RoundRotorQuadratic, val::Dict{String, Any}) = value.ext = val
+"""Set RoundRotorQuadratic saturation_coeffs."""
+set_saturation_coeffs!(value::RoundRotorQuadratic, val::Tuple{Float64, Float64}) = value.saturation_coeffs = val
+"""Set RoundRotorQuadratic states."""
+set_states!(value::RoundRotorQuadratic, val::Vector{Symbol}) = value.states = val
+"""Set RoundRotorQuadratic n_states."""
+set_n_states!(value::RoundRotorQuadratic, val::Int64) = value.n_states = val
+"""Set RoundRotorQuadratic internal."""
+set_internal!(value::RoundRotorQuadratic, val::InfrastructureSystemsInternal) = value.internal = val

--- a/src/models/generated/SalientPoleQuadratic.jl
+++ b/src/models/generated/SalientPoleQuadratic.jl
@@ -1,0 +1,165 @@
+#=
+This file is auto-generated. Do not edit.
+=#
+"""
+    mutable struct SalientPoleQuadratic <: Machine
+        R::Float64
+        Td0_p::Float64
+        Td0_pp::Float64
+        Tq0_pp::Float64
+        Xd::Float64
+        Xq::Float64
+        Xd_p::Float64
+        Xd_pp::Float64
+        Xl::Float64
+        Se::Tuple{Float64, Float64}
+        ext::Dict{String, Any}
+        saturation_coeffs::Tuple{Float64, Float64}
+        states::Vector{Symbol}
+        n_states::Int64
+        internal::InfrastructureSystemsInternal
+    end
+
+Parameters of 3-states salient-pole synchronous machine with quadratic saturation:
+IEEE Std 1110 §5.3.1 (Model 2.1). GENSAL model in PSSE and PSLF.
+
+# Arguments
+- `R::Float64`: Armature resistance, validation range: (0, nothing)
+- `Td0_p::Float64`: Time constant of transient d-axis voltage, validation range: (0, nothing)
+- `Td0_pp::Float64`: Time constant of sub-transient d-axis voltage, validation range: (0, nothing)
+- `Tq0_pp::Float64`: Time constant of sub-transient q-axis voltage, validation range: (0, nothing)
+- `Xd::Float64`: Reactance after EMF in d-axis per unit, validation range: (0, nothing)
+- `Xq::Float64`: Reactance after EMF in q-axis per unit, validation range: (0, nothing)
+- `Xd_p::Float64`: Transient reactance after EMF in d-axis per unit, validation range: (0, nothing)
+- `Xd_pp::Float64`: Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp, validation range: (0, nothing)
+- `Xl::Float64`: Stator leakage reactance, validation range: (0, nothing)
+- `Se::Tuple{Float64, Float64}`: Saturation factor at 1 and 1.2 pu flux: Se(eq_p) = B(eq_p-A)^2
+- `ext::Dict{String, Any}`
+- `saturation_coeffs::Tuple{Float64, Float64}`: Saturation coefficients of quadratic saturation: (A, B): Se = B(eq_p-A)^2
+- `states::Vector{Symbol}`: The states are:
+	eq_p: q-axis generator voltage behind the transient reactance,
+	ψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,
+	ψq_pp: phasonf of the subtransient flux linkage in the q-axis
+- `n_states::Int64`
+- `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
+"""
+mutable struct SalientPoleQuadratic <: Machine
+    "Armature resistance"
+    R::Float64
+    "Time constant of transient d-axis voltage"
+    Td0_p::Float64
+    "Time constant of sub-transient d-axis voltage"
+    Td0_pp::Float64
+    "Time constant of sub-transient q-axis voltage"
+    Tq0_pp::Float64
+    "Reactance after EMF in d-axis per unit"
+    Xd::Float64
+    "Reactance after EMF in q-axis per unit"
+    Xq::Float64
+    "Transient reactance after EMF in d-axis per unit"
+    Xd_p::Float64
+    "Sub-Transient reactance after EMF in d-axis per unit. Note: Xd_pp = Xq_pp"
+    Xd_pp::Float64
+    "Stator leakage reactance"
+    Xl::Float64
+    "Saturation factor at 1 and 1.2 pu flux: Se(eq_p) = B(eq_p-A)^2"
+    Se::Tuple{Float64, Float64}
+    ext::Dict{String, Any}
+    "Saturation coefficients of quadratic saturation: (A, B): Se = B(eq_p-A)^2"
+    saturation_coeffs::Tuple{Float64, Float64}
+    "The states are:
+	eq_p: q-axis generator voltage behind the transient reactance,
+	ψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,
+	ψq_pp: phasonf of the subtransient flux linkage in the q-axis"
+    states::Vector{Symbol}
+    n_states::Int64
+    "power system internal reference, do not modify"
+    internal::InfrastructureSystemsInternal
+end
+
+function SalientPoleQuadratic(R, Td0_p, Td0_pp, Tq0_pp, Xd, Xq, Xd_p, Xd_pp, Xl, Se, ext=Dict{String, Any}(), )
+    SalientPoleQuadratic(R, Td0_p, Td0_pp, Tq0_pp, Xd, Xq, Xd_p, Xd_pp, Xl, Se, ext, get_quadratic_saturation(Se), [:eq_p, :ψ_kd, :ψq_pp], 3, InfrastructureSystemsInternal(), )
+end
+
+function SalientPoleQuadratic(; R, Td0_p, Td0_pp, Tq0_pp, Xd, Xq, Xd_p, Xd_pp, Xl, Se, ext=Dict{String, Any}(), )
+    SalientPoleQuadratic(R, Td0_p, Td0_pp, Tq0_pp, Xd, Xq, Xd_p, Xd_pp, Xl, Se, ext, )
+end
+
+# Constructor for demo purposes; non-functional.
+function SalientPoleQuadratic(::Nothing)
+    SalientPoleQuadratic(;
+        R=0,
+        Td0_p=0,
+        Td0_pp=0,
+        Tq0_pp=0,
+        Xd=0,
+        Xq=0,
+        Xd_p=0,
+        Xd_pp=0,
+        Xl=0,
+        Se=(0.0, 0.0),
+        ext=Dict{String, Any}(),
+    )
+end
+
+"""Get SalientPoleQuadratic R."""
+get_R(value::SalientPoleQuadratic) = value.R
+"""Get SalientPoleQuadratic Td0_p."""
+get_Td0_p(value::SalientPoleQuadratic) = value.Td0_p
+"""Get SalientPoleQuadratic Td0_pp."""
+get_Td0_pp(value::SalientPoleQuadratic) = value.Td0_pp
+"""Get SalientPoleQuadratic Tq0_pp."""
+get_Tq0_pp(value::SalientPoleQuadratic) = value.Tq0_pp
+"""Get SalientPoleQuadratic Xd."""
+get_Xd(value::SalientPoleQuadratic) = value.Xd
+"""Get SalientPoleQuadratic Xq."""
+get_Xq(value::SalientPoleQuadratic) = value.Xq
+"""Get SalientPoleQuadratic Xd_p."""
+get_Xd_p(value::SalientPoleQuadratic) = value.Xd_p
+"""Get SalientPoleQuadratic Xd_pp."""
+get_Xd_pp(value::SalientPoleQuadratic) = value.Xd_pp
+"""Get SalientPoleQuadratic Xl."""
+get_Xl(value::SalientPoleQuadratic) = value.Xl
+"""Get SalientPoleQuadratic Se."""
+get_Se(value::SalientPoleQuadratic) = value.Se
+"""Get SalientPoleQuadratic ext."""
+get_ext(value::SalientPoleQuadratic) = value.ext
+"""Get SalientPoleQuadratic saturation_coeffs."""
+get_saturation_coeffs(value::SalientPoleQuadratic) = value.saturation_coeffs
+"""Get SalientPoleQuadratic states."""
+get_states(value::SalientPoleQuadratic) = value.states
+"""Get SalientPoleQuadratic n_states."""
+get_n_states(value::SalientPoleQuadratic) = value.n_states
+"""Get SalientPoleQuadratic internal."""
+get_internal(value::SalientPoleQuadratic) = value.internal
+
+"""Set SalientPoleQuadratic R."""
+set_R!(value::SalientPoleQuadratic, val::Float64) = value.R = val
+"""Set SalientPoleQuadratic Td0_p."""
+set_Td0_p!(value::SalientPoleQuadratic, val::Float64) = value.Td0_p = val
+"""Set SalientPoleQuadratic Td0_pp."""
+set_Td0_pp!(value::SalientPoleQuadratic, val::Float64) = value.Td0_pp = val
+"""Set SalientPoleQuadratic Tq0_pp."""
+set_Tq0_pp!(value::SalientPoleQuadratic, val::Float64) = value.Tq0_pp = val
+"""Set SalientPoleQuadratic Xd."""
+set_Xd!(value::SalientPoleQuadratic, val::Float64) = value.Xd = val
+"""Set SalientPoleQuadratic Xq."""
+set_Xq!(value::SalientPoleQuadratic, val::Float64) = value.Xq = val
+"""Set SalientPoleQuadratic Xd_p."""
+set_Xd_p!(value::SalientPoleQuadratic, val::Float64) = value.Xd_p = val
+"""Set SalientPoleQuadratic Xd_pp."""
+set_Xd_pp!(value::SalientPoleQuadratic, val::Float64) = value.Xd_pp = val
+"""Set SalientPoleQuadratic Xl."""
+set_Xl!(value::SalientPoleQuadratic, val::Float64) = value.Xl = val
+"""Set SalientPoleQuadratic Se."""
+set_Se!(value::SalientPoleQuadratic, val::Tuple{Float64, Float64}) = value.Se = val
+"""Set SalientPoleQuadratic ext."""
+set_ext!(value::SalientPoleQuadratic, val::Dict{String, Any}) = value.ext = val
+"""Set SalientPoleQuadratic saturation_coeffs."""
+set_saturation_coeffs!(value::SalientPoleQuadratic, val::Tuple{Float64, Float64}) = value.saturation_coeffs = val
+"""Set SalientPoleQuadratic states."""
+set_states!(value::SalientPoleQuadratic, val::Vector{Symbol}) = value.states = val
+"""Set SalientPoleQuadratic n_states."""
+set_n_states!(value::SalientPoleQuadratic, val::Int64) = value.n_states = val
+"""Set SalientPoleQuadratic internal."""
+set_internal!(value::SalientPoleQuadratic, val::InfrastructureSystemsInternal) = value.internal = val

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -30,6 +30,8 @@ include("AVRSimple.jl")
 include("AVRTypeI.jl")
 include("AVRTypeII.jl")
 include("BaseMachine.jl")
+include("RoundRotorQuadratic.jl")
+include("SalientPoleQuadratic.jl")
 include("AndersonFouadMachine.jl")
 include("FullMachine.jl")
 include("MarconatoMachine.jl")
@@ -98,6 +100,7 @@ export get_R
 export get_R_1d
 export get_R_1q
 export get_R_f
+export get_Se
 export get_T1
 export get_T2
 export get_T3
@@ -123,6 +126,7 @@ export get_X_th
 export get_Xd
 export get_Xd_p
 export get_Xd_pp
+export get_Xl
 export get_Xq
 export get_Xq_p
 export get_Xq_pp
@@ -210,6 +214,7 @@ export get_rf
 export get_rg
 export get_rv
 export get_s_rated
+export get_saturation_coeffs
 export get_services
 export get_shutdn
 export get_startup
@@ -278,6 +283,7 @@ export set_R!
 export set_R_1d!
 export set_R_1q!
 export set_R_f!
+export set_Se!
 export set_T1!
 export set_T2!
 export set_T3!
@@ -303,6 +309,7 @@ export set_X_th!
 export set_Xd!
 export set_Xd_p!
 export set_Xd_pp!
+export set_Xl!
 export set_Xq!
 export set_Xq_p!
 export set_Xq_pp!
@@ -390,6 +397,7 @@ export set_rf!
 export set_rg!
 export set_rv!
 export set_s_rated!
+export set_saturation_coeffs!
 export set_services!
 export set_shutdn!
 export set_startup!

--- a/src/models/regulation_device.jl
+++ b/src/models/regulation_device.jl
@@ -14,23 +14,42 @@ mutable struct RegulationDevice{T <: StaticInjection} <: Device
         reserve_limit_up::Float64,
         reserve_limit_dn::Float64,
         inertia::Float64,
-        cost::Float64
+        cost::Float64,
     ) where {T <: StaticInjection}
         IS.@forward((RegulationDevice{T}, :device), T)
-        new{T}(device, droop, participation_factor, reserve_limit_up, reserve_limit_dn, inertia, cost)
+        new{T}(
+            device,
+            droop,
+            participation_factor,
+            reserve_limit_up,
+            reserve_limit_dn,
+            inertia,
+            cost,
+        )
     end
 end
 
 function RegulationDevice(
     device::T;
     droop::Float64 = Inf,
-    participation_factor::NamedTuple{(:up, :dn), Tuple{Float64, Float64}} = (up = 0.0, dn = 0.0),
+    participation_factor::NamedTuple{(:up, :dn), Tuple{Float64, Float64}} = (
+        up = 0.0,
+        dn = 0.0,
+    ),
     reserve_limit_up::Float64 = 0.0,
     reserve_limit_dn::Float64 = 0.0,
     inertia::Float64 = 0.0,
-    cost::Float64 = 1.0
+    cost::Float64 = 1.0,
 ) where {T <: StaticInjection}
-    return RegulationDevice{T}(device, droop, participation_factor, reserve_limit_up, reserve_limit_dn, inertia, cost)
+    return RegulationDevice{T}(
+        device,
+        droop,
+        participation_factor,
+        reserve_limit_up,
+        reserve_limit_dn,
+        inertia,
+        cost,
+    )
 end
 
 function has_forecasts(d::RegulationDevice)

--- a/test/test_dynamic_generator.jl
+++ b/test/test_dynamic_generator.jl
@@ -52,6 +52,36 @@ branch_OMIB = [Line(
     )
     @test Basic isa PowerSystems.DynamicComponent
 
+    GENROU = RoundRotorQuadratic(
+        0.0, #R
+        7.4, #Td0_p
+        0.03, #Td0_pp
+        0.06, #Tq0_p
+        0.033, #Tq0_pp
+        0.8979, #Xd
+        0.646, #Xq
+        0.2995, #Xd_p
+        0.646, #Xq_p
+        0.23, #Xd_pp
+        0.1, #Xl
+        (0.1, 0.5), #Se
+    )
+    @test GENROU isa PowerSystems.DynamicComponent
+
+    GENSAL = SalientPoleQuadratic(
+        0.0, #R
+        7.4, #Td0_p
+        0.03, #Td0_pp
+        0.033, #Tq0_pp
+        0.8979, #Xd
+        0.646, #Xq
+        0.2995, #Xd_p
+        0.23, #Xd_pp
+        0.1, #Xl
+        (0.1, 0.5), #Se
+    )
+    @test GENSAL isa PowerSystems.DynamicComponent
+
     oneDoneQ = OneDOneQMachine(
         0.0, #R
         0.8979, #Xd
@@ -336,6 +366,10 @@ end
 
     # Rule: Can't remove a static injector if it is attached to a dynamic injector.
     @test_throws ArgumentError remove_component!(sys, static_gen)
+
+    #Rule: Can't add saturation if Se(1.2) <= Se(1.0)
+    @test_throws IS.ConflictingInputsError PSY.get_quadratic_saturation((0.5, 0.1))
+    @test_throws IS.ConflictingInputsError PSY.get_quadratic_saturation((0.1, 0.1))
 
     @test length(collect(get_dynamic_components(Gen2AVR))) == 5
 end


### PR DESCRIPTION
The following PR provides the two struct used for standard Round Rotor and Salient Pole (GENROU and GENSAL) models.

The saturation coefficients are computed using a specific function, that solves a quadratic equation directly.