### PR TITLE
[WIP] Update Dynamic Models Structs

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -157,6 +157,7 @@ export BusTypes
 export LoadModels
 export PrimeMovers
 export ThermalFuels
+export StateTypes
 
 export Forecast
 export Deterministic

--- a/src/common.jl
+++ b/src/common.jl
@@ -72,6 +72,12 @@ IS.@scoped_enum ThermalFuel begin
     OTHER # OTH     # Other
 end
 
+IS.@scoped_enum StateType begin
+    Differential
+    Algebraic
+    Hybrid
+end
+
 PS_MAX_LOG = parse(Int, get(ENV, "PS_MAX_LOG", "50"))
 DEFAULT_BASE_MVA = 100.0
 

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -4201,7 +4201,7 @@
         },
         {
           "name": "states",
-          "comment": "The states are:\n\teψd: d-axis stator flux,\n\tψq: q-axis stator flux,\n\tψf: field rotor flux,\n\tψ1d: d-axis rotor damping flux,\n\tψ1q: q-axis rotor damping flux",
+          "comment": "The states are:\n\tψd: d-axis stator flux,\n\tψq: q-axis stator flux,\n\tψf: field rotor flux,\n\tψ1d: d-axis rotor damping flux,\n\tψ1q: q-axis rotor damping flux",
           "internal_default": "[:ψd, :ψq, :ψf, :ψ1d, :ψ1q]",
           "data_type": "Vector{Symbol}"
         },
@@ -4364,7 +4364,7 @@
         },
         {
           "name": "states",
-          "comment": "The states are:\n\teψq: q-axis stator flux,\n\tψd: d-axis stator flux,\n\teq_p: q-axis transient voltage,\n\ted_p: d-axis transient voltage,\n\teq_pp: q-axis subtransient voltage,\n\ted_pp: d-axis subtransient voltage",
+          "comment": "The states are:\n\tψq: q-axis stator flux,\n\tψd: d-axis stator flux,\n\teq_p: q-axis transient voltage,\n\ted_p: d-axis transient voltage,\n\teq_pp: q-axis subtransient voltage,\n\ted_pp: d-axis subtransient voltage",
           "internal_default": "[:ψq, :ψd, :eq_p, :ed_p, :eq_pp, :ed_pp]",
           "data_type": "Vector{Symbol}"
         },

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2613,6 +2613,12 @@
           "data_type": "Int64"
         },
         {
+          "name": "states_types",
+          "comment": "Fixed AVR has no states",
+          "internal_default": "Vector{StateTypes.StateType}()",
+          "data_type": "Vector{StateTypes.StateType}"
+        },
+        {
           "name": "internal",
           "comment": "power system internal reference, do not modify",
           "data_type": "InfrastructureSystemsInternal",
@@ -2654,7 +2660,7 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states are:\n\tVf: field voltage",
           "internal_default": "[:Vf]",
           "data_type": "Vector{Symbol}"
         },
@@ -2663,6 +2669,12 @@
           "comment": "Fixed AVR has 1 states",
           "internal_default": 1,
           "data_type": "Int64"
+        },
+        {
+          "name": "states_types",
+          "comment": "Simple AVR has 1 differential states",
+          "internal_default": "[StateTypes.Differential]",
+          "data_type": "Vector{StateTypes.StateType}"
         },
         {
           "name": "internal",
@@ -2806,15 +2818,21 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states are:\n\tVf: Voltage field,\n\tVr1: Amplifier State,\n\tVr2: Stabilizing Feedback State,\n\tVm: Measured voltage",
           "internal_default": "[:Vf, :Vr1, :Vr2, :Vm]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "The AVR Type I has 4 states",
           "internal_default": 4,
           "data_type": "Int64"
+        },
+        {
+          "name": "states_types",
+          "comment": "AVR Type I has 4 differential states",
+          "internal_default": "[StateTypes.Differential, StateTypes.Differential, StateTypes.Differential, StateTypes.Differential]",
+          "data_type": "Vector{StateTypes.StateType}"
         },
         {
           "name": "internal",
@@ -2958,15 +2976,21 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states are:\n\tVf: Voltage field,\n\tVr1: First Lead-Lag state,\n\tVr2: Second lead-lag state,\n\tVm: Measured voltage",
           "internal_default": "[:Vf, :Vr1, :Vr2, :Vm]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "AVR Type II has 4 states",
           "internal_default": 4,
           "data_type": "Int64"
+        },
+        {
+          "name": "states_types",
+          "comment": "AVR Type II has 4 differential states",
+          "internal_default": "[StateTypes.Differential, StateTypes.Differential, StateTypes.Differential, StateTypes.Differential]",
+          "data_type": "Vector{StateTypes.StateType}"
         },
         {
           "name": "internal",
@@ -3147,9 +3171,15 @@
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "AC1A has 5 states",
           "internal_default": 5,
           "data_type": "Int64"
+        },
+        {
+          "name": "states_types",
+          "comment": "AC1A has 5 states",
+          "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Differential]",
+          "data_type": "Vector{StateTypes.StateType}"
         },
         {
           "name": "internal",
@@ -3327,6 +3357,12 @@
           "comment": "",
           "internal_default": 5,
           "data_type": "Int64"
+        },
+        {
+          "name": "states_types",
+          "comment": "ModifiedAC1A has 5 states",
+          "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Differential]",
+          "data_type": "Vector{StateTypes.StateType}"
         },
         {
           "name": "internal",
@@ -3526,9 +3562,15 @@
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "ST1A has 5 states",
           "internal_default": 5,
           "data_type": "Int64"
+        },
+        {
+          "name": "states_types",
+          "comment": "ST1A has 5 states",
+          "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential]",
+          "data_type": "Vector{StateTypes.StateType}"
         },
         {
           "name": "internal",

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -3623,13 +3623,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "BaseMachine has no states",
           "internal_default": "Vector{Symbol}()",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "BaseMachine has no states",
           "internal_default": 0,
           "data_type": "Int64"
         },
@@ -3776,7 +3776,7 @@
             },
             {
                 "name": "n_states",
-                "comment": "",
+                "comment": "RoundRotorMachine has 4 states",
                 "internal_default": 4,
                 "data_type": "Int64"
             },
@@ -3903,7 +3903,7 @@
             },
             {
                 "name": "n_states",
-                "comment": "",
+                "comment": "SalientPoleMachine has 3 states",
                 "internal_default": 3,
                 "data_type": "Int64"
             },
@@ -4038,13 +4038,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states are:\n\teψq: q-axis stator flux,\n\tψd: d-axis stator flux,\n\teq_p: q-axis transient voltage,\n\ted_p: d-axis transient voltage,\n\teq_pp: q-axis subtransient voltage,\n\ted_pp: d-axis subtransient voltage",
           "internal_default": "[:ψq, :ψd, :eq_p, :ed_p, :eq_pp, :ed_pp]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "AndersonFouadMachine has 6 states",
           "internal_default": 6,
           "data_type": "Int64"
         },
@@ -4201,13 +4201,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states are:\n\teψd: d-axis stator flux,\n\tψq: q-axis stator flux,\n\tψf: field rotor flux,\n\tψ1d: d-axis rotor damping flux,\n\tψ1q: q-axis rotor damping flux",
           "internal_default": "[:ψd, :ψq, :ψf, :ψ1d, :ψ1q]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "FullMachine has 5 states",
           "internal_default": 5,
           "data_type": "Int64"
         },
@@ -4364,13 +4364,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states are:\n\teψq: q-axis stator flux,\n\tψd: d-axis stator flux,\n\teq_p: q-axis transient voltage,\n\ted_p: d-axis transient voltage,\n\teq_pp: q-axis subtransient voltage,\n\ted_pp: d-axis subtransient voltage",
           "internal_default": "[:ψq, :ψd, :eq_p, :ed_p, :eq_pp, :ed_pp]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "MarconatoMachine has 6 states",
           "internal_default": 6,
           "data_type": "Int64"
         },
@@ -4465,13 +4465,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states are:\n\teq_p: q-axis transient voltage,\n\ted_p: d-axis transient voltage",
           "internal_default": "[:eq_p, :ed_p]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "OneDOneQMachine has 2 states",
           "internal_default": 2,
           "data_type": "Int64"
         },
@@ -4606,13 +4606,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states are:\n\teq_p: q-axis transient voltage,\n\ted_p: d-axis transient voltage,\n\teq_pp: q-axis subtransient voltage,\n\ted_pp: d-axis subtransient voltage",
           "internal_default": "[:eq_p, :ed_p, :eq_pp, :ed_pp]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "SimpleAFMachine has 4 states",
           "internal_default": 4,
           "data_type": "Int64"
         },
@@ -4769,13 +4769,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states are:\n\tψf: field rotor flux,\n\tψ1d: d-axis rotor damping flux,\n\tψ1q: q-axis rotor damping flux",
           "internal_default": "[:ψf, :ψ1d, :ψ1q]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "SimpleFullMachine has 3 states",
           "internal_default": 3,
           "data_type": "Int64"
         },
@@ -4932,13 +4932,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states are:\n\teq_p: q-axis transient voltage,\n\ted_p: d-axis transient voltage,\n\teq_pp: q-axis subtransient voltage,\n\ted_pp: d-axis subtransient voltage",
           "internal_default": "[:eq_p, :ed_p, :eq_pp, :ed_pp]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "SimpleMarconatoMachine has 4 states",
           "internal_default": 4,
           "data_type": "Int64"
         },
@@ -4979,7 +4979,7 @@
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "PSSFixed has no states",
           "internal_default": 0,
           "data_type": "Int64"
         },
@@ -5030,7 +5030,7 @@
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "PSSSimple has no states",
           "internal_default": 0,
           "data_type": "Int64"
         },
@@ -5075,13 +5075,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states are:\n\tδ: rotor angle,\n\tω: rotor speed",
           "internal_default": "[:δ, :ω]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "SingleMass has 1 state",
           "internal_default": 2,
           "data_type": "Int64"
         },
@@ -5286,13 +5286,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states are:\n\tδ: rotor angle,\n\tω: rotor speed,\n\tδ_hp: rotor angle of high pressure turbine,\n\tω_hp: rotor speed of high pressure turbine,\n\tδ_ip: rotor angle of intermediate pressure turbine,\n\tω_ip: rotor speed of intermediate pressure turbine,\n\tδ_lp: rotor angle of low pressure turbine,\n\tω_lp: rotor speed of low pressure turbine,\n\tδ_ex: rotor angle of exciter,\n\tω_lp: rotor speed of exciter",
           "internal_default": "[:δ, :ω, :δ_hp, :ω_hp, :δ_ip, :ω_ip, :δ_lp, :ω_lp, :δ_ex, :ω_ex]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "FiveMassShaft has 10 states",
           "internal_default": 10,
           "data_type": "Int64"
         },
@@ -5344,7 +5344,7 @@
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "TGFixed has no states",
           "internal_default": 0,
           "data_type": "Int64"
         },
@@ -5456,13 +5456,13 @@
         },
         {
           "name": "states",
-          "comment": "The states of the GAST model are:\n\tx_g1: Fuel valve opening\n\tx_g2: Fuel flow\n\tx_g3: Exhaust temperature load",
+          "comment": "The states of the GAST model are:\n\tx_g1: Fuel valve opening,\n\tx_g2: Fuel flow,\n\tx_g3: Exhaust temperature load",
           "internal_default": "[:x_g1, :x_g2, :x_g3]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "GasTG has 3 states",
           "internal_default": 3,
           "data_type": "Int64"
         },
@@ -5578,13 +5578,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states of the TGTypeI model are:\n\tx_g1: Governor state,\n\tx_g2: Servo state,\n\tx_g3: Reheat state",
           "internal_default": "[:x_g1, :x_g2, :x_g3]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "TGTypeI has 3 states",
           "internal_default": 3,
           "data_type": "Int64"
         },
@@ -5670,13 +5670,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states of the TGTypeI model are:\n\tx_g1: lead-lag state",
           "internal_default": "[:xg]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "TGTypeII has 1 state",
           "internal_default": 1,
           "data_type": "Int64"
         },
@@ -5727,7 +5727,7 @@
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "AverageConverter has no states",
           "internal_default": 0,
           "data_type": "Int64"
         }
@@ -5762,7 +5762,7 @@
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "FixedDCSource has no states",
           "internal_default": 0,
           "data_type": "Int64"
         },
@@ -5837,13 +5837,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states of the LCLFilter model are:\n\tir_cnv: Real current out of the converter,\n\tii_cnv: Imaginary current out of the converter,\n\tvr_filter: Real voltage at the filter's capacitor,\n\tvi_filter: Imaginary voltage at the filter's capacitor,\n\tir_filter: Real current out of the filter,\n\tii_filter: Imaginary current out of the filter",
           "internal_default": "[:ir_cnv, :ii_cnv, :vr_filter, :vi_filter, :ir_filter, :ii_filter]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "LCLFilter has 6 states",
           "internal_default": 6,
           "data_type": "Int64"
         }
@@ -5892,14 +5892,14 @@
         },
         {
           "name": "states",
-          "comment": "",
-          "internal_default": "[:id_o, :iq_o]",
+          "comment": "The states of the LCFilter model are:\n\tir_filter: Real current out of the filter,\n\tii_filter: Imaginary current out of the filter",
+          "internal_default": "[:ir_filter, :ii_filter]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
-          "internal_default": 4,
+          "comment": "LCFilter has two states",
+          "internal_default": 2,
           "data_type": "Int64"
         }
       ],
@@ -5907,7 +5907,7 @@
     },
     {
       "struct_name": "KauraPLL",
-      "docstring": "Parameters of a Phase-Locked Loop (PLL) based on Kaura, Vikram, and Vladimir Blasko. \"Operation of a phase locked loop system under distorted utility conditions.\" IEEE Transactions on Industry applications 33.1 (1997): 58-63.",
+      "docstring": "Parameters of a Phase-Locked Loop (PLL) based on Kaura, Vikram, and Vladimir Blasko.\n\"Operation of a phase locked loop system under distorted utility conditions.\"\nIEEE Transactions on Industry applications 33.1 (1997): 58-63.",
       "fields": [
         {
           "name": "ω_lp",
@@ -5947,13 +5947,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states of the KauraPLL model are:\n\tvd_pll: d-axis of the measured voltage in the PLL synchronous reference frame (SRF),\n\tvq_pll: q-axis of the measured voltage in the PLL SRF,\n\tε_pll: Integrator state of the PI controller,\n\tθ_pll: Phase angle displacement in the PLL SRF",
           "internal_default": "[:vd_pll, :vq_pll, :ε_pll, :θ_pll]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "KauraPLL has 4 states",
           "internal_default": 4,
           "data_type": "Int64"
         }
@@ -6013,13 +6013,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states of the VirtualInertia model are:\n\tω_oc: Speed of the rotating reference frame of the virtual synchronous generator model,\n\tθ_oc: Phase angle displacement of the virtual synchronous generator model",
           "internal_default": "[:ω_oc, :θ_oc]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "VirtualInertia has two states",
           "internal_default": 2,
           "data_type": "Int64"
         }
@@ -6069,13 +6069,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states of the ReactivePowerDroop model are:\n\tq_oc: Filtered reactive output power",
           "internal_default": "[:q_oc]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "ReactivePowerDroop has 1 state",
           "internal_default": 1,
           "data_type": "Int64"
         }
@@ -6084,7 +6084,7 @@
     },
     {
       "struct_name": "CurrentControl",
-      "docstring": "Parameters of an inner loop current control PID using virtual impedance.",
+      "docstring": "Parameters of an inner loop current control PID using virtual impedance based on D'Arco, Suul and Fosso.\n\"A Virtual Synchronous Machine implementation for distributed control of power converters in SmartGrids.\"\nElectric Power Systems Research 122 (2015) 180–197.",
       "fields": [
         {
           "name": "kpv",
@@ -6194,13 +6194,13 @@
         },
         {
           "name": "states",
-          "comment": "",
+          "comment": "The states of the VirtualInertia model are:\n\tξd_ic: d-axis integrator state of the PI voltage controller,\n\tξq_ic: q-axis integrator state of the PI voltage controller,\n\tγd_ic: d-axis integrator state of the PI current controller,\n\tγq_ic: q-axis integrator state of the PI current controller,\n\tϕd_ic: d-axis low-pass filter of active damping,\n\tϕq_ic: q-axis low-pass filter of active damping",
           "internal_default": "[:ξd_ic, :ξq_ic, :γd_ic, :γq_ic, :ϕd_ic, :ϕq_ic]",
           "data_type": "Vector{Symbol}"
         },
         {
           "name": "n_states",
-          "comment": "",
+          "comment": "CurrentControl has 6 states",
           "internal_default": 6,
           "data_type": "Int64"
         }

--- a/src/models/generated/AC1A.jl
+++ b/src/models/generated/AC1A.jl
@@ -23,6 +23,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
+        states_types::Vector{StateTypes.StateType}
         internal::InfrastructureSystemsInternal
     end
 
@@ -55,7 +56,8 @@ Parameters of IEEE Std 421.5 Type AC1A Excitacion System. ESAC1A in PSSE and PSL
 	Vr2: Regulator output state,
 	Ve: Integrator output state,
 	Vr3: Feedback output state
-- `n_states::Int64`
+- `n_states::Int64`: AC1A has 5 states
+- `states_types::Vector{StateTypes.StateType}`: AC1A has 5 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct AC1A <: AVR
@@ -101,13 +103,16 @@ mutable struct AC1A <: AVR
 	Ve: Integrator output state,
 	Vr3: Feedback output state"
     states::Vector{Symbol}
+    "AC1A has 5 states"
     n_states::Int64
+    "AC1A has 5 states"
+    states_types::Vector{StateTypes.StateType}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
 function AC1A(Tr, Tb, Tc, Ka, Ta, Va_lim, Te, Kf, Tf, Kc, Kd, Ke, E_sat, Se, Vr_lim, V_ref=1.0, saturation_coeffs=PowerSystems.get_avr_saturation(E_sat, Se), ext=Dict{String, Any}(), )
-    AC1A(Tr, Tb, Tc, Ka, Ta, Va_lim, Te, Kf, Tf, Kc, Kd, Ke, E_sat, Se, Vr_lim, V_ref, saturation_coeffs, ext, [:Vm, :Vr1, :Vr2, :Ve, :Vr3], 5, InfrastructureSystemsInternal(), )
+    AC1A(Tr, Tb, Tc, Ka, Ta, Va_lim, Te, Kf, Tf, Kc, Kd, Ke, E_sat, Se, Vr_lim, V_ref, saturation_coeffs, ext, [:Vm, :Vr1, :Vr2, :Ve, :Vr3], 5, [StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Differential], InfrastructureSystemsInternal(), )
 end
 
 function AC1A(; Tr, Tb, Tc, Ka, Ta, Va_lim, Te, Kf, Tf, Kc, Kd, Ke, E_sat, Se, Vr_lim, V_ref=1.0, saturation_coeffs=PowerSystems.get_avr_saturation(E_sat, Se), ext=Dict{String, Any}(), )
@@ -178,6 +183,8 @@ get_ext(value::AC1A) = value.ext
 get_states(value::AC1A) = value.states
 """Get AC1A n_states."""
 get_n_states(value::AC1A) = value.n_states
+"""Get AC1A states_types."""
+get_states_types(value::AC1A) = value.states_types
 """Get AC1A internal."""
 get_internal(value::AC1A) = value.internal
 
@@ -221,5 +228,7 @@ set_ext!(value::AC1A, val::Dict{String, Any}) = value.ext = val
 set_states!(value::AC1A, val::Vector{Symbol}) = value.states = val
 """Set AC1A n_states."""
 set_n_states!(value::AC1A, val::Int64) = value.n_states = val
+"""Set AC1A states_types."""
+set_states_types!(value::AC1A, val::Vector{StateTypes.StateType}) = value.states_types = val
 """Set AC1A internal."""
 set_internal!(value::AC1A, val::InfrastructureSystemsInternal) = value.internal = val

--- a/src/models/generated/AVRFixed.jl
+++ b/src/models/generated/AVRFixed.jl
@@ -7,6 +7,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
+        states_types::Vector{StateTypes.StateType}
         internal::InfrastructureSystemsInternal
     end
 
@@ -17,6 +18,7 @@ Parameters of a AVR that returns a fixed voltage to the rotor winding
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: Fixed AVR has no states
 - `n_states::Int64`: Fixed AVR has no states
+- `states_types::Vector{StateTypes.StateType}`: Fixed AVR has no states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct AVRFixed <: AVR
@@ -27,12 +29,14 @@ mutable struct AVRFixed <: AVR
     states::Vector{Symbol}
     "Fixed AVR has no states"
     n_states::Int64
+    "Fixed AVR has no states"
+    states_types::Vector{StateTypes.StateType}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
 function AVRFixed(Vf, ext=Dict{String, Any}(), )
-    AVRFixed(Vf, ext, Vector{Symbol}(), 0, InfrastructureSystemsInternal(), )
+    AVRFixed(Vf, ext, Vector{Symbol}(), 0, Vector{StateTypes.StateType}(), InfrastructureSystemsInternal(), )
 end
 
 function AVRFixed(; Vf, ext=Dict{String, Any}(), )
@@ -55,6 +59,8 @@ get_ext(value::AVRFixed) = value.ext
 get_states(value::AVRFixed) = value.states
 """Get AVRFixed n_states."""
 get_n_states(value::AVRFixed) = value.n_states
+"""Get AVRFixed states_types."""
+get_states_types(value::AVRFixed) = value.states_types
 """Get AVRFixed internal."""
 get_internal(value::AVRFixed) = value.internal
 
@@ -66,5 +72,7 @@ set_ext!(value::AVRFixed, val::Dict{String, Any}) = value.ext = val
 set_states!(value::AVRFixed, val::Vector{Symbol}) = value.states = val
 """Set AVRFixed n_states."""
 set_n_states!(value::AVRFixed, val::Int64) = value.n_states = val
+"""Set AVRFixed states_types."""
+set_states_types!(value::AVRFixed, val::Vector{StateTypes.StateType}) = value.states_types = val
 """Set AVRFixed internal."""
 set_internal!(value::AVRFixed, val::InfrastructureSystemsInternal) = value.internal = val

--- a/src/models/generated/AVRSimple.jl
+++ b/src/models/generated/AVRSimple.jl
@@ -8,6 +8,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
+        states_types::Vector{StateTypes.StateType}
         internal::InfrastructureSystemsInternal
     end
 
@@ -18,8 +19,10 @@ i.e. an integrator controller on EMF
 - `Kv::Float64`: Proportional Gain, validation range: (0, nothing)
 - `V_ref::Float64`: Reference Voltage Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
+- `states::Vector{Symbol}`: The states are:
+	Vf: field voltage
 - `n_states::Int64`: Fixed AVR has 1 states
+- `states_types::Vector{StateTypes.StateType}`: Simple AVR has 1 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct AVRSimple <: AVR
@@ -28,15 +31,19 @@ mutable struct AVRSimple <: AVR
     "Reference Voltage Set-point"
     V_ref::Float64
     ext::Dict{String, Any}
+    "The states are:
+	Vf: field voltage"
     states::Vector{Symbol}
     "Fixed AVR has 1 states"
     n_states::Int64
+    "Simple AVR has 1 differential states"
+    states_types::Vector{StateTypes.StateType}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
 function AVRSimple(Kv, V_ref=1.0, ext=Dict{String, Any}(), )
-    AVRSimple(Kv, V_ref, ext, [:Vf], 1, InfrastructureSystemsInternal(), )
+    AVRSimple(Kv, V_ref, ext, [:Vf], 1, [StateTypes.Differential], InfrastructureSystemsInternal(), )
 end
 
 function AVRSimple(; Kv, V_ref=1.0, ext=Dict{String, Any}(), )
@@ -62,6 +69,8 @@ get_ext(value::AVRSimple) = value.ext
 get_states(value::AVRSimple) = value.states
 """Get AVRSimple n_states."""
 get_n_states(value::AVRSimple) = value.n_states
+"""Get AVRSimple states_types."""
+get_states_types(value::AVRSimple) = value.states_types
 """Get AVRSimple internal."""
 get_internal(value::AVRSimple) = value.internal
 
@@ -75,5 +84,7 @@ set_ext!(value::AVRSimple, val::Dict{String, Any}) = value.ext = val
 set_states!(value::AVRSimple, val::Vector{Symbol}) = value.states = val
 """Set AVRSimple n_states."""
 set_n_states!(value::AVRSimple, val::Int64) = value.n_states = val
+"""Set AVRSimple states_types."""
+set_states_types!(value::AVRSimple, val::Vector{StateTypes.StateType}) = value.states_types = val
 """Set AVRSimple internal."""
 set_internal!(value::AVRSimple, val::InfrastructureSystemsInternal) = value.internal = val

--- a/src/models/generated/AVRTypeI.jl
+++ b/src/models/generated/AVRTypeI.jl
@@ -18,6 +18,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
+        states_types::Vector{StateTypes.StateType}
         internal::InfrastructureSystemsInternal
     end
 
@@ -37,8 +38,13 @@ Parameters of an Automatic Voltage Regulator Type I - Resembles IEEE Type DC1
 - `Be::Float64`: 2nd ceiling coefficient, validation range: (0, nothing)
 - `V_ref::Float64`: Reference Voltage Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states are:
+	Vf: Voltage field,
+	Vr1: Amplifier State,
+	Vr2: Stabilizing Feedback State,
+	Vm: Measured voltage
+- `n_states::Int64`: The AVR Type I has 4 states
+- `states_types::Vector{StateTypes.StateType}`: AVR Type I has 4 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct AVRTypeI <: AVR
@@ -67,14 +73,22 @@ mutable struct AVRTypeI <: AVR
     "Reference Voltage Set-point"
     V_ref::Float64
     ext::Dict{String, Any}
+    "The states are:
+	Vf: Voltage field,
+	Vr1: Amplifier State,
+	Vr2: Stabilizing Feedback State,
+	Vm: Measured voltage"
     states::Vector{Symbol}
+    "The AVR Type I has 4 states"
     n_states::Int64
+    "AVR Type I has 4 differential states"
+    states_types::Vector{StateTypes.StateType}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
 function AVRTypeI(Ka, Ke, Kf, Ta, Te, Tf, Tr, Vr_max, Vr_min, Ae, Be, V_ref=1.0, ext=Dict{String, Any}(), )
-    AVRTypeI(Ka, Ke, Kf, Ta, Te, Tf, Tr, Vr_max, Vr_min, Ae, Be, V_ref, ext, [:Vf, :Vr1, :Vr2, :Vm], 4, InfrastructureSystemsInternal(), )
+    AVRTypeI(Ka, Ke, Kf, Ta, Te, Tf, Tr, Vr_max, Vr_min, Ae, Be, V_ref, ext, [:Vf, :Vr1, :Vr2, :Vm], 4, [StateTypes.Differential, StateTypes.Differential, StateTypes.Differential, StateTypes.Differential], InfrastructureSystemsInternal(), )
 end
 
 function AVRTypeI(; Ka, Ke, Kf, Ta, Te, Tf, Tr, Vr_max, Vr_min, Ae, Be, V_ref=1.0, ext=Dict{String, Any}(), )
@@ -130,6 +144,8 @@ get_ext(value::AVRTypeI) = value.ext
 get_states(value::AVRTypeI) = value.states
 """Get AVRTypeI n_states."""
 get_n_states(value::AVRTypeI) = value.n_states
+"""Get AVRTypeI states_types."""
+get_states_types(value::AVRTypeI) = value.states_types
 """Get AVRTypeI internal."""
 get_internal(value::AVRTypeI) = value.internal
 
@@ -163,5 +179,7 @@ set_ext!(value::AVRTypeI, val::Dict{String, Any}) = value.ext = val
 set_states!(value::AVRTypeI, val::Vector{Symbol}) = value.states = val
 """Set AVRTypeI n_states."""
 set_n_states!(value::AVRTypeI, val::Int64) = value.n_states = val
+"""Set AVRTypeI states_types."""
+set_states_types!(value::AVRTypeI, val::Vector{StateTypes.StateType}) = value.states_types = val
 """Set AVRTypeI internal."""
 set_internal!(value::AVRTypeI, val::InfrastructureSystemsInternal) = value.internal = val

--- a/src/models/generated/AVRTypeII.jl
+++ b/src/models/generated/AVRTypeII.jl
@@ -18,6 +18,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
+        states_types::Vector{StateTypes.StateType}
         internal::InfrastructureSystemsInternal
     end
 
@@ -37,8 +38,13 @@ Parameters of an Automatic Voltage Regulator Type II -  Typical static exciter m
 - `Be::Float64`: 2nd ceiling coefficient, validation range: (0, nothing)
 - `V_ref::Float64`: Reference Voltage Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states are:
+	Vf: Voltage field,
+	Vr1: First Lead-Lag state,
+	Vr2: Second lead-lag state,
+	Vm: Measured voltage
+- `n_states::Int64`: AVR Type II has 4 states
+- `states_types::Vector{StateTypes.StateType}`: AVR Type II has 4 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct AVRTypeII <: AVR
@@ -67,14 +73,22 @@ mutable struct AVRTypeII <: AVR
     "Reference Voltage Set-point"
     V_ref::Float64
     ext::Dict{String, Any}
+    "The states are:
+	Vf: Voltage field,
+	Vr1: First Lead-Lag state,
+	Vr2: Second lead-lag state,
+	Vm: Measured voltage"
     states::Vector{Symbol}
+    "AVR Type II has 4 states"
     n_states::Int64
+    "AVR Type II has 4 differential states"
+    states_types::Vector{StateTypes.StateType}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
 function AVRTypeII(K0, T1, T2, T3, T4, Te, Tr, Vr_max, Vr_min, Ae, Be, V_ref=1.0, ext=Dict{String, Any}(), )
-    AVRTypeII(K0, T1, T2, T3, T4, Te, Tr, Vr_max, Vr_min, Ae, Be, V_ref, ext, [:Vf, :Vr1, :Vr2, :Vm], 4, InfrastructureSystemsInternal(), )
+    AVRTypeII(K0, T1, T2, T3, T4, Te, Tr, Vr_max, Vr_min, Ae, Be, V_ref, ext, [:Vf, :Vr1, :Vr2, :Vm], 4, [StateTypes.Differential, StateTypes.Differential, StateTypes.Differential, StateTypes.Differential], InfrastructureSystemsInternal(), )
 end
 
 function AVRTypeII(; K0, T1, T2, T3, T4, Te, Tr, Vr_max, Vr_min, Ae, Be, V_ref=1.0, ext=Dict{String, Any}(), )
@@ -130,6 +144,8 @@ get_ext(value::AVRTypeII) = value.ext
 get_states(value::AVRTypeII) = value.states
 """Get AVRTypeII n_states."""
 get_n_states(value::AVRTypeII) = value.n_states
+"""Get AVRTypeII states_types."""
+get_states_types(value::AVRTypeII) = value.states_types
 """Get AVRTypeII internal."""
 get_internal(value::AVRTypeII) = value.internal
 
@@ -163,5 +179,7 @@ set_ext!(value::AVRTypeII, val::Dict{String, Any}) = value.ext = val
 set_states!(value::AVRTypeII, val::Vector{Symbol}) = value.states = val
 """Set AVRTypeII n_states."""
 set_n_states!(value::AVRTypeII, val::Int64) = value.n_states = val
+"""Set AVRTypeII states_types."""
+set_states_types!(value::AVRTypeII, val::Vector{StateTypes.StateType}) = value.states_types = val
 """Set AVRTypeII internal."""
 set_internal!(value::AVRTypeII, val::InfrastructureSystemsInternal) = value.internal = val

--- a/src/models/generated/AndersonFouadMachine.jl
+++ b/src/models/generated/AndersonFouadMachine.jl
@@ -35,8 +35,14 @@ Parameters of 6-states synchronous machine: Anderson-Fouad model
 - `Td0_pp::Float64`: Time constant of sub-transient d-axis voltage, validation range: (0, nothing)
 - `Tq0_pp::Float64`: Time constant of sub-transient q-axis voltage, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states are:
+	eψq: q-axis stator flux,
+	ψd: d-axis stator flux,
+	eq_p: q-axis transient voltage,
+	ed_p: d-axis transient voltage,
+	eq_pp: q-axis subtransient voltage,
+	ed_pp: d-axis subtransient voltage
+- `n_states::Int64`: AndersonFouadMachine has 6 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct AndersonFouadMachine <: Machine
@@ -63,7 +69,15 @@ mutable struct AndersonFouadMachine <: Machine
     "Time constant of sub-transient q-axis voltage"
     Tq0_pp::Float64
     ext::Dict{String, Any}
+    "The states are:
+	eψq: q-axis stator flux,
+	ψd: d-axis stator flux,
+	eq_p: q-axis transient voltage,
+	ed_p: d-axis transient voltage,
+	eq_pp: q-axis subtransient voltage,
+	ed_pp: d-axis subtransient voltage"
     states::Vector{Symbol}
+    "AndersonFouadMachine has 6 states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/AverageConverter.jl
+++ b/src/models/generated/AverageConverter.jl
@@ -17,7 +17,7 @@ Parameters of an average converter model
 - `s_rated::Float64`: rated VA, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
-- `n_states::Int64`
+- `n_states::Int64`: AverageConverter has no states
 """
 mutable struct AverageConverter <: Converter
     "rated voltage"
@@ -26,6 +26,7 @@ mutable struct AverageConverter <: Converter
     s_rated::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
+    "AverageConverter has no states"
     n_states::Int64
 end
 

--- a/src/models/generated/BaseMachine.jl
+++ b/src/models/generated/BaseMachine.jl
@@ -19,8 +19,8 @@ Parameters of a Classic Machine: GENCLS in PSSE and PSLF
 - `Xd_p::Float64`: Reactance after EMF in machine per unit, validation range: (0, nothing)
 - `eq_p::Float64`: Fixed EMF behind the impedance, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: BaseMachine has no states
+- `n_states::Int64`: BaseMachine has no states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct BaseMachine <: Machine
@@ -31,7 +31,9 @@ mutable struct BaseMachine <: Machine
     "Fixed EMF behind the impedance"
     eq_p::Float64
     ext::Dict{String, Any}
+    "BaseMachine has no states"
     states::Vector{Symbol}
+    "BaseMachine has no states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/CurrentControl.jl
+++ b/src/models/generated/CurrentControl.jl
@@ -18,7 +18,9 @@ This file is auto-generated. Do not edit.
         n_states::Int64
     end
 
-Parameters of an inner loop current control PID using virtual impedance.
+Parameters of an inner loop current control PID using virtual impedance based on D'Arco, Suul and Fosso.
+"A Virtual Synchronous Machine implementation for distributed control of power converters in SmartGrids."
+Electric Power Systems Research 122 (2015) 180–197.
 
 # Arguments
 - `kpv::Float64`: voltage controller proportional gain, validation range: (0, nothing)
@@ -32,8 +34,14 @@ Parameters of an inner loop current control PID using virtual impedance.
 - `ωad::Float64`: active damping filter cutoff frequency (rad/sec), validation range: (0, nothing)
 - `kad::Float64`: active damping gain, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states of the VirtualInertia model are:
+	ξd_ic: d-axis integrator state of the PI voltage controller,
+	ξq_ic: q-axis integrator state of the PI voltage controller,
+	γd_ic: d-axis integrator state of the PI current controller,
+	γq_ic: q-axis integrator state of the PI current controller,
+	ϕd_ic: d-axis low-pass filter of active damping,
+	ϕq_ic: q-axis low-pass filter of active damping
+- `n_states::Int64`: CurrentControl has 6 states
 """
 mutable struct CurrentControl <: InnerControl
     "voltage controller proportional gain"
@@ -57,7 +65,15 @@ mutable struct CurrentControl <: InnerControl
     "active damping gain"
     kad::Float64
     ext::Dict{String, Any}
+    "The states of the VirtualInertia model are:
+	ξd_ic: d-axis integrator state of the PI voltage controller,
+	ξq_ic: q-axis integrator state of the PI voltage controller,
+	γd_ic: d-axis integrator state of the PI current controller,
+	γq_ic: q-axis integrator state of the PI current controller,
+	ϕd_ic: d-axis low-pass filter of active damping,
+	ϕq_ic: q-axis low-pass filter of active damping"
     states::Vector{Symbol}
+    "CurrentControl has 6 states"
     n_states::Int64
 end
 

--- a/src/models/generated/FiveMassShaft.jl
+++ b/src/models/generated/FiveMassShaft.jl
@@ -51,8 +51,18 @@ Parameters of 5 mass-spring shaft model.
 - `K_lp::Float64`: Low pressure turbine angle coefficient, validation range: (0, nothing)
 - `K_ex::Float64`: Exciter angle coefficient, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states are:
+	δ: rotor angle,
+	ω: rotor speed,
+	δ_hp: rotor angle of high pressure turbine,
+	ω_hp: rotor speed of high pressure turbine,
+	δ_ip: rotor angle of intermediate pressure turbine,
+	ω_ip: rotor speed of intermediate pressure turbine,
+	δ_lp: rotor angle of low pressure turbine,
+	ω_lp: rotor speed of low pressure turbine,
+	δ_ex: rotor angle of exciter,
+	ω_lp: rotor speed of exciter
+- `n_states::Int64`: FiveMassShaft has 10 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct FiveMassShaft <: Shaft
@@ -93,7 +103,19 @@ mutable struct FiveMassShaft <: Shaft
     "Exciter angle coefficient"
     K_ex::Float64
     ext::Dict{String, Any}
+    "The states are:
+	δ: rotor angle,
+	ω: rotor speed,
+	δ_hp: rotor angle of high pressure turbine,
+	ω_hp: rotor speed of high pressure turbine,
+	δ_ip: rotor angle of intermediate pressure turbine,
+	ω_ip: rotor speed of intermediate pressure turbine,
+	δ_lp: rotor angle of low pressure turbine,
+	ω_lp: rotor speed of low pressure turbine,
+	δ_ex: rotor angle of exciter,
+	ω_lp: rotor speed of exciter"
     states::Vector{Symbol}
+    "FiveMassShaft has 10 states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/FixedDCSource.jl
+++ b/src/models/generated/FixedDCSource.jl
@@ -16,7 +16,7 @@ Parameters of a Fixed DC Source that returns a fixed DC voltage
 - `voltage::Float64`: rated VA, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
-- `n_states::Int64`
+- `n_states::Int64`: FixedDCSource has no states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct FixedDCSource <: DCSource
@@ -24,6 +24,7 @@ mutable struct FixedDCSource <: DCSource
     voltage::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
+    "FixedDCSource has no states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/FullMachine.jl
+++ b/src/models/generated/FullMachine.jl
@@ -44,8 +44,13 @@ Parameter of a full order flux stator-rotor model without zero sequence flux in 
 - `ext::Dict{String, Any}`
 - `inv_d_fluxlink::Array{Float64,2}`: Equations 3.127, 3.130, 3.131 From Kundur
 - `inv_q_fluxlink::Array{Float64,2}`: Equations 3.128, 3.132 From Kundur
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states are:
+	eψd: d-axis stator flux,
+	ψq: q-axis stator flux,
+	ψf: field rotor flux,
+	ψ1d: d-axis rotor damping flux,
+	ψ1q: q-axis rotor damping flux
+- `n_states::Int64`: FullMachine has 5 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct FullMachine <: Machine
@@ -78,7 +83,14 @@ mutable struct FullMachine <: Machine
     inv_d_fluxlink::Array{Float64,2}
     "Equations 3.128, 3.132 From Kundur"
     inv_q_fluxlink::Array{Float64,2}
+    "The states are:
+	eψd: d-axis stator flux,
+	ψq: q-axis stator flux,
+	ψf: field rotor flux,
+	ψ1d: d-axis rotor damping flux,
+	ψ1q: q-axis rotor damping flux"
     states::Vector{Symbol}
+    "FullMachine has 5 states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/FullMachine.jl
+++ b/src/models/generated/FullMachine.jl
@@ -45,7 +45,7 @@ Parameter of a full order flux stator-rotor model without zero sequence flux in 
 - `inv_d_fluxlink::Array{Float64,2}`: Equations 3.127, 3.130, 3.131 From Kundur
 - `inv_q_fluxlink::Array{Float64,2}`: Equations 3.128, 3.132 From Kundur
 - `states::Vector{Symbol}`: The states are:
-	eψd: d-axis stator flux,
+	ψd: d-axis stator flux,
 	ψq: q-axis stator flux,
 	ψf: field rotor flux,
 	ψ1d: d-axis rotor damping flux,
@@ -84,7 +84,7 @@ mutable struct FullMachine <: Machine
     "Equations 3.128, 3.132 From Kundur"
     inv_q_fluxlink::Array{Float64,2}
     "The states are:
-	eψd: d-axis stator flux,
+	ψd: d-axis stator flux,
 	ψq: q-axis stator flux,
 	ψf: field rotor flux,
 	ψ1d: d-axis rotor damping flux,

--- a/src/models/generated/GasTG.jl
+++ b/src/models/generated/GasTG.jl
@@ -32,10 +32,10 @@ Parameters of Gas Turbine-Governor. GAST in PSSE and GAST_PTI in PowerWorld.
 - `Load_ref::Float64`: Reference Load Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: The states of the GAST model are:
-	x_g1: Fuel valve opening
-	x_g2: Fuel flow
+	x_g1: Fuel valve opening,
+	x_g2: Fuel flow,
 	x_g3: Exhaust temperature load
-- `n_states::Int64`
+- `n_states::Int64`: GasTG has 3 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct GasTG <: TurbineGov
@@ -59,10 +59,11 @@ mutable struct GasTG <: TurbineGov
     Load_ref::Float64
     ext::Dict{String, Any}
     "The states of the GAST model are:
-	x_g1: Fuel valve opening
-	x_g2: Fuel flow
+	x_g1: Fuel valve opening,
+	x_g2: Fuel flow,
 	x_g3: Exhaust temperature load"
     states::Vector{Symbol}
+    "GasTG has 3 states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/KauraPLL.jl
+++ b/src/models/generated/KauraPLL.jl
@@ -11,15 +11,21 @@ This file is auto-generated. Do not edit.
         n_states::Int64
     end
 
-Parameters of a Phase-Locked Loop (PLL) based on Kaura, Vikram, and Vladimir Blasko. "Operation of a phase locked loop system under distorted utility conditions." IEEE Transactions on Industry applications 33.1 (1997): 58-63.
+Parameters of a Phase-Locked Loop (PLL) based on Kaura, Vikram, and Vladimir Blasko.
+"Operation of a phase locked loop system under distorted utility conditions."
+IEEE Transactions on Industry applications 33.1 (1997): 58-63.
 
 # Arguments
 - `ω_lp::Float64`: PLL low-pass filter frequency (rad/sec), validation range: (0, nothing)
 - `kp_pll::Float64`: PLL proportional gain, validation range: (0, nothing)
 - `ki_pll::Float64`: PLL integral gain, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states of the KauraPLL model are:
+	vd_pll: d-axis of the measured voltage in the PLL synchronous reference frame (SRF),
+	vq_pll: q-axis of the measured voltage in the PLL SRF,
+	ε_pll: Integrator state of the PI controller,
+	θ_pll: Phase angle displacement in the PLL SRF
+- `n_states::Int64`: KauraPLL has 4 states
 """
 mutable struct KauraPLL <: FrequencyEstimator
     "PLL low-pass filter frequency (rad/sec)"
@@ -29,7 +35,13 @@ mutable struct KauraPLL <: FrequencyEstimator
     "PLL integral gain"
     ki_pll::Float64
     ext::Dict{String, Any}
+    "The states of the KauraPLL model are:
+	vd_pll: d-axis of the measured voltage in the PLL synchronous reference frame (SRF),
+	vq_pll: q-axis of the measured voltage in the PLL SRF,
+	ε_pll: Integrator state of the PI controller,
+	θ_pll: Phase angle displacement in the PLL SRF"
     states::Vector{Symbol}
+    "KauraPLL has 4 states"
     n_states::Int64
 end
 

--- a/src/models/generated/LCFilter.jl
+++ b/src/models/generated/LCFilter.jl
@@ -18,8 +18,10 @@ Parameters of a LCL filter outside the converter
 - `rf::Float64`: filter resistance, validation range: (0, nothing)
 - `cf::Float64`: filter capacitance, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states of the LCFilter model are:
+	ir_filter: Real current out of the filter,
+	ii_filter: Imaginary current out of the filter
+- `n_states::Int64`: LCFilter has two states
 """
 mutable struct LCFilter <: Filter
     "filter inductance"
@@ -29,12 +31,16 @@ mutable struct LCFilter <: Filter
     "filter capacitance"
     cf::Float64
     ext::Dict{String, Any}
+    "The states of the LCFilter model are:
+	ir_filter: Real current out of the filter,
+	ii_filter: Imaginary current out of the filter"
     states::Vector{Symbol}
+    "LCFilter has two states"
     n_states::Int64
 end
 
 function LCFilter(lf, rf, cf, ext=Dict{String, Any}(), )
-    LCFilter(lf, rf, cf, ext, [:id_o, :iq_o], 4, )
+    LCFilter(lf, rf, cf, ext, [:ir_filter, :ii_filter], 2, )
 end
 
 function LCFilter(; lf, rf, cf, ext=Dict{String, Any}(), )

--- a/src/models/generated/LCLFilter.jl
+++ b/src/models/generated/LCLFilter.jl
@@ -22,8 +22,14 @@ Parameters of a LCL filter outside the converter, the states are in the grid's r
 - `lg::Float64`: Series inductance in p.u. of converter filter to the grid, validation range: (0, nothing)
 - `rg::Float64`: Series resistance in p.u. of converter filter to the grid, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states of the LCLFilter model are:
+	ir_cnv: Real current out of the converter,
+	ii_cnv: Imaginary current out of the converter,
+	vr_filter: Real voltage at the filter's capacitor,
+	vi_filter: Imaginary voltage at the filter's capacitor,
+	ir_filter: Real current out of the filter,
+	ii_filter: Imaginary current out of the filter
+- `n_states::Int64`: LCLFilter has 6 states
 """
 mutable struct LCLFilter <: Filter
     "Series inductance in p.u. of converter filter"
@@ -37,7 +43,15 @@ mutable struct LCLFilter <: Filter
     "Series resistance in p.u. of converter filter to the grid"
     rg::Float64
     ext::Dict{String, Any}
+    "The states of the LCLFilter model are:
+	ir_cnv: Real current out of the converter,
+	ii_cnv: Imaginary current out of the converter,
+	vr_filter: Real voltage at the filter's capacitor,
+	vi_filter: Imaginary voltage at the filter's capacitor,
+	ir_filter: Real current out of the filter,
+	ii_filter: Imaginary current out of the filter"
     states::Vector{Symbol}
+    "LCLFilter has 6 states"
     n_states::Int64
 end
 

--- a/src/models/generated/MarconatoMachine.jl
+++ b/src/models/generated/MarconatoMachine.jl
@@ -42,7 +42,7 @@ Parameters of 6-states synchronous machine: Marconato model
 - `γd::Float64`
 - `γq::Float64`
 - `states::Vector{Symbol}`: The states are:
-	eψq: q-axis stator flux,
+	ψq: q-axis stator flux,
 	ψd: d-axis stator flux,
 	eq_p: q-axis transient voltage,
 	ed_p: d-axis transient voltage,
@@ -80,7 +80,7 @@ mutable struct MarconatoMachine <: Machine
     γd::Float64
     γq::Float64
     "The states are:
-	eψq: q-axis stator flux,
+	ψq: q-axis stator flux,
 	ψd: d-axis stator flux,
 	eq_p: q-axis transient voltage,
 	ed_p: d-axis transient voltage,

--- a/src/models/generated/MarconatoMachine.jl
+++ b/src/models/generated/MarconatoMachine.jl
@@ -41,8 +41,14 @@ Parameters of 6-states synchronous machine: Marconato model
 - `ext::Dict{String, Any}`
 - `γd::Float64`
 - `γq::Float64`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states are:
+	eψq: q-axis stator flux,
+	ψd: d-axis stator flux,
+	eq_p: q-axis transient voltage,
+	ed_p: d-axis transient voltage,
+	eq_pp: q-axis subtransient voltage,
+	ed_pp: d-axis subtransient voltage
+- `n_states::Int64`: MarconatoMachine has 6 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct MarconatoMachine <: Machine
@@ -73,7 +79,15 @@ mutable struct MarconatoMachine <: Machine
     ext::Dict{String, Any}
     γd::Float64
     γq::Float64
+    "The states are:
+	eψq: q-axis stator flux,
+	ψd: d-axis stator flux,
+	eq_p: q-axis transient voltage,
+	ed_p: d-axis transient voltage,
+	eq_pp: q-axis subtransient voltage,
+	ed_pp: d-axis subtransient voltage"
     states::Vector{Symbol}
+    "MarconatoMachine has 6 states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/ModifiedAC1A.jl
+++ b/src/models/generated/ModifiedAC1A.jl
@@ -22,6 +22,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
+        states_types::Vector{StateTypes.StateType}
         internal::InfrastructureSystemsInternal
     end
 
@@ -52,6 +53,7 @@ Parameters of Modified Type AC1A Excitacion System. EXAC1 in PSSE and PSLF
 	Ve: Integrator output state,
 	Vr3: Feedback output state
 - `n_states::Int64`
+- `states_types::Vector{StateTypes.StateType}`: ModifiedAC1A has 5 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct ModifiedAC1A <: AVR
@@ -96,12 +98,14 @@ mutable struct ModifiedAC1A <: AVR
 	Vr3: Feedback output state"
     states::Vector{Symbol}
     n_states::Int64
+    "ModifiedAC1A has 5 states"
+    states_types::Vector{StateTypes.StateType}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
 function ModifiedAC1A(Tr, Tb, Tc, Ka, Ta, Vr_lim, Te, Kf, Tf, Kc, Kd, Ke, E_sat, Se, V_ref=1.0, saturation_coeffs=PowerSystems.get_avr_saturation(E_sat, Se), ext=Dict{String, Any}(), )
-    ModifiedAC1A(Tr, Tb, Tc, Ka, Ta, Vr_lim, Te, Kf, Tf, Kc, Kd, Ke, E_sat, Se, V_ref, saturation_coeffs, ext, [:Vm, :Vr1, :Vr2, :Ve, :Vr3], 5, InfrastructureSystemsInternal(), )
+    ModifiedAC1A(Tr, Tb, Tc, Ka, Ta, Vr_lim, Te, Kf, Tf, Kc, Kd, Ke, E_sat, Se, V_ref, saturation_coeffs, ext, [:Vm, :Vr1, :Vr2, :Ve, :Vr3], 5, [StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Differential], InfrastructureSystemsInternal(), )
 end
 
 function ModifiedAC1A(; Tr, Tb, Tc, Ka, Ta, Vr_lim, Te, Kf, Tf, Kc, Kd, Ke, E_sat, Se, V_ref=1.0, saturation_coeffs=PowerSystems.get_avr_saturation(E_sat, Se), ext=Dict{String, Any}(), )
@@ -169,6 +173,8 @@ get_ext(value::ModifiedAC1A) = value.ext
 get_states(value::ModifiedAC1A) = value.states
 """Get ModifiedAC1A n_states."""
 get_n_states(value::ModifiedAC1A) = value.n_states
+"""Get ModifiedAC1A states_types."""
+get_states_types(value::ModifiedAC1A) = value.states_types
 """Get ModifiedAC1A internal."""
 get_internal(value::ModifiedAC1A) = value.internal
 
@@ -210,5 +216,7 @@ set_ext!(value::ModifiedAC1A, val::Dict{String, Any}) = value.ext = val
 set_states!(value::ModifiedAC1A, val::Vector{Symbol}) = value.states = val
 """Set ModifiedAC1A n_states."""
 set_n_states!(value::ModifiedAC1A, val::Int64) = value.n_states = val
+"""Set ModifiedAC1A states_types."""
+set_states_types!(value::ModifiedAC1A, val::Vector{StateTypes.StateType}) = value.states_types = val
 """Set ModifiedAC1A internal."""
 set_internal!(value::ModifiedAC1A, val::InfrastructureSystemsInternal) = value.internal = val

--- a/src/models/generated/OneDOneQMachine.jl
+++ b/src/models/generated/OneDOneQMachine.jl
@@ -30,8 +30,10 @@ Parameters of 4-states synchronous machine: Simplified Marconato model
 - `Td0_p::Float64`: Time constant of transient d-axis voltage, validation range: (0, nothing)
 - `Tq0_p::Float64`: Time constant of transient q-axis voltage, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states are:
+	eq_p: q-axis transient voltage,
+	ed_p: d-axis transient voltage
+- `n_states::Int64`: OneDOneQMachine has 2 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct OneDOneQMachine <: Machine
@@ -50,7 +52,11 @@ mutable struct OneDOneQMachine <: Machine
     "Time constant of transient q-axis voltage"
     Tq0_p::Float64
     ext::Dict{String, Any}
+    "The states are:
+	eq_p: q-axis transient voltage,
+	ed_p: d-axis transient voltage"
     states::Vector{Symbol}
+    "OneDOneQMachine has 2 states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/PSSFixed.jl
+++ b/src/models/generated/PSSFixed.jl
@@ -16,7 +16,7 @@ Parameters of a PSS that returns a fixed voltage to add to the reference for the
 - `V_pss::Float64`: Fixed voltage stabilization signal, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
-- `n_states::Int64`
+- `n_states::Int64`: PSSFixed has no states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct PSSFixed <: PSS
@@ -24,6 +24,7 @@ mutable struct PSSFixed <: PSS
     V_pss::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
+    "PSSFixed has no states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/PSSSimple.jl
+++ b/src/models/generated/PSSSimple.jl
@@ -18,7 +18,7 @@ Parameters of a PSS that returns a proportional droop voltage to add to the refe
 - `K_p::Float64`: Proportional gain for active power, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
-- `n_states::Int64`
+- `n_states::Int64`: PSSSimple has no states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct PSSSimple <: PSS
@@ -28,6 +28,7 @@ mutable struct PSSSimple <: PSS
     K_p::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
+    "PSSSimple has no states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/ReactivePowerDroop.jl
+++ b/src/models/generated/ReactivePowerDroop.jl
@@ -18,8 +18,9 @@ Parameters of a Reactive Power droop controller
 - `ωf::Float64`: filter frequency cutoff, validation range: (0, nothing)
 - `V_ref::Float64`: Reference Voltage Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states of the ReactivePowerDroop model are:
+	q_oc: Filtered reactive output power
+- `n_states::Int64`: ReactivePowerDroop has 1 state
 """
 mutable struct ReactivePowerDroop <: ReactivePowerControl
     "frequency droop gain"
@@ -29,7 +30,10 @@ mutable struct ReactivePowerDroop <: ReactivePowerControl
     "Reference Voltage Set-point"
     V_ref::Float64
     ext::Dict{String, Any}
+    "The states of the ReactivePowerDroop model are:
+	q_oc: Filtered reactive output power"
     states::Vector{Symbol}
+    "ReactivePowerDroop has 1 state"
     n_states::Int64
 end
 

--- a/src/models/generated/RoundRotorMachine.jl
+++ b/src/models/generated/RoundRotorMachine.jl
@@ -43,7 +43,7 @@ IEEE Std 1110 §5.3.2 (Model 2.2). GENROU or GENROE model in PSSE and PSLF.
 	ed_p: d-axis generator voltage behind the transient reactance,
 	ψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,
 	ψ_kq: flux linkage in the first equivalent damping circuit in the d-axis
-- `n_states::Int64`
+- `n_states::Int64`: RoundRotorMachine has 4 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct RoundRotorMachine <: Machine
@@ -78,6 +78,7 @@ mutable struct RoundRotorMachine <: Machine
 	ψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,
 	ψ_kq: flux linkage in the first equivalent damping circuit in the d-axis"
     states::Vector{Symbol}
+    "RoundRotorMachine has 4 states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/ST1A.jl
+++ b/src/models/generated/ST1A.jl
@@ -24,6 +24,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int64
+        states_types::Vector{StateTypes.StateType}
         internal::InfrastructureSystemsInternal
     end
 
@@ -56,7 +57,8 @@ Parameters of IEEE Std 421.5 Type ST1A Excitacion System. ESST1A in PSSE and PSL
 	Vr2: Second lead-lag state,
 	Va: Regulator output state,
 	Vr3: Feedback output state
-- `n_states::Int64`
+- `n_states::Int64`: ST1A has 5 states
+- `states_types::Vector{StateTypes.StateType}`: ST1A has 5 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct ST1A <: AVR
@@ -104,13 +106,16 @@ mutable struct ST1A <: AVR
 	Va: Regulator output state,
 	Vr3: Feedback output state"
     states::Vector{Symbol}
+    "ST1A has 5 states"
     n_states::Int64
+    "ST1A has 5 states"
+    states_types::Vector{StateTypes.StateType}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
 function ST1A(UEL_flags, PSS_flags, Tr, Vi_lim, Tc, Tb, Tc1, Tb1, Ka, Ta, Va_lim, Vr_lim, Kc, Kf, Tf, K_lr, I_lr, V_ref=1.0, ext=Dict{String, Any}(), )
-    ST1A(UEL_flags, PSS_flags, Tr, Vi_lim, Tc, Tb, Tc1, Tb1, Ka, Ta, Va_lim, Vr_lim, Kc, Kf, Tf, K_lr, I_lr, V_ref, ext, [:Vm, :Vr1, :Vr2, :Va, :Vr3], 5, InfrastructureSystemsInternal(), )
+    ST1A(UEL_flags, PSS_flags, Tr, Vi_lim, Tc, Tb, Tc1, Tb1, Ka, Ta, Va_lim, Vr_lim, Kc, Kf, Tf, K_lr, I_lr, V_ref, ext, [:Vm, :Vr1, :Vr2, :Va, :Vr3], 5, [StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential], InfrastructureSystemsInternal(), )
 end
 
 function ST1A(; UEL_flags, PSS_flags, Tr, Vi_lim, Tc, Tb, Tc1, Tb1, Ka, Ta, Va_lim, Vr_lim, Kc, Kf, Tf, K_lr, I_lr, V_ref=1.0, ext=Dict{String, Any}(), )
@@ -184,6 +189,8 @@ get_ext(value::ST1A) = value.ext
 get_states(value::ST1A) = value.states
 """Get ST1A n_states."""
 get_n_states(value::ST1A) = value.n_states
+"""Get ST1A states_types."""
+get_states_types(value::ST1A) = value.states_types
 """Get ST1A internal."""
 get_internal(value::ST1A) = value.internal
 
@@ -229,5 +236,7 @@ set_ext!(value::ST1A, val::Dict{String, Any}) = value.ext = val
 set_states!(value::ST1A, val::Vector{Symbol}) = value.states = val
 """Set ST1A n_states."""
 set_n_states!(value::ST1A, val::Int64) = value.n_states = val
+"""Set ST1A states_types."""
+set_states_types!(value::ST1A, val::Vector{StateTypes.StateType}) = value.states_types = val
 """Set ST1A internal."""
 set_internal!(value::ST1A, val::InfrastructureSystemsInternal) = value.internal = val

--- a/src/models/generated/SalientPoleMachine.jl
+++ b/src/models/generated/SalientPoleMachine.jl
@@ -38,7 +38,7 @@ IEEE Std 1110 §5.3.1 (Model 2.1). GENSAL or GENSAE model in PSSE and PSLF.
 	eq_p: q-axis generator voltage behind the transient reactance,
 	ψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,
 	ψq_pp: phasonf of the subtransient flux linkage in the q-axis
-- `n_states::Int64`
+- `n_states::Int64`: SalientPoleMachine has 3 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct SalientPoleMachine <: Machine
@@ -68,6 +68,7 @@ mutable struct SalientPoleMachine <: Machine
 	ψ_kd: flux linkage in the first equivalent damping circuit in the d-axis,
 	ψq_pp: phasonf of the subtransient flux linkage in the q-axis"
     states::Vector{Symbol}
+    "SalientPoleMachine has 3 states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/SimpleAFMachine.jl
+++ b/src/models/generated/SimpleAFMachine.jl
@@ -39,8 +39,12 @@ Parameters of 4-states simplified Anderson-Fouad (SimpleAFMachine) model.
 - `Td0_pp::Float64`: Time constant of sub-transient d-axis voltage, validation range: (0, nothing)
 - `Tq0_pp::Float64`: Time constant of sub-transient q-axis voltage, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states are:
+	eq_p: q-axis transient voltage,
+	ed_p: d-axis transient voltage,
+	eq_pp: q-axis subtransient voltage,
+	ed_pp: d-axis subtransient voltage
+- `n_states::Int64`: SimpleAFMachine has 4 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct SimpleAFMachine <: Machine
@@ -67,7 +71,13 @@ mutable struct SimpleAFMachine <: Machine
     "Time constant of sub-transient q-axis voltage"
     Tq0_pp::Float64
     ext::Dict{String, Any}
+    "The states are:
+	eq_p: q-axis transient voltage,
+	ed_p: d-axis transient voltage,
+	eq_pp: q-axis subtransient voltage,
+	ed_pp: d-axis subtransient voltage"
     states::Vector{Symbol}
+    "SimpleAFMachine has 4 states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/SimpleFullMachine.jl
+++ b/src/models/generated/SimpleFullMachine.jl
@@ -46,8 +46,11 @@ Parameter of a full order flux stator-rotor model without zero sequence flux in 
 - `ext::Dict{String, Any}`
 - `inv_d_fluxlink::Array{Float64,2}`: Equations 3.127, 3.130, 3.131 From Kundur
 - `inv_q_fluxlink::Array{Float64,2}`: Equations 3.128, 3.132 From Kundur
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states are:
+	ψf: field rotor flux,
+	ψ1d: d-axis rotor damping flux,
+	ψ1q: q-axis rotor damping flux
+- `n_states::Int64`: SimpleFullMachine has 3 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct SimpleFullMachine <: Machine
@@ -80,7 +83,12 @@ mutable struct SimpleFullMachine <: Machine
     inv_d_fluxlink::Array{Float64,2}
     "Equations 3.128, 3.132 From Kundur"
     inv_q_fluxlink::Array{Float64,2}
+    "The states are:
+	ψf: field rotor flux,
+	ψ1d: d-axis rotor damping flux,
+	ψ1q: q-axis rotor damping flux"
     states::Vector{Symbol}
+    "SimpleFullMachine has 3 states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/SimpleMarconatoMachine.jl
+++ b/src/models/generated/SimpleMarconatoMachine.jl
@@ -44,8 +44,12 @@ Parameters of 4-states synchronous machine: Simplified Marconato model
 - `ext::Dict{String, Any}`
 - `γd::Float64`
 - `γq::Float64`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states are:
+	eq_p: q-axis transient voltage,
+	ed_p: d-axis transient voltage,
+	eq_pp: q-axis subtransient voltage,
+	ed_pp: d-axis subtransient voltage
+- `n_states::Int64`: SimpleMarconatoMachine has 4 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct SimpleMarconatoMachine <: Machine
@@ -76,7 +80,13 @@ mutable struct SimpleMarconatoMachine <: Machine
     ext::Dict{String, Any}
     γd::Float64
     γq::Float64
+    "The states are:
+	eq_p: q-axis transient voltage,
+	ed_p: d-axis transient voltage,
+	eq_pp: q-axis subtransient voltage,
+	ed_pp: d-axis subtransient voltage"
     states::Vector{Symbol}
+    "SimpleMarconatoMachine has 4 states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/SingleMass.jl
+++ b/src/models/generated/SingleMass.jl
@@ -17,8 +17,10 @@ Parameters of single mass shaft model. Typically represents the rotor mass.
 - `H::Float64`: Rotor inertia constant in MWs/MVA, validation range: (0, nothing)
 - `D::Float64`: Rotor natural damping in pu, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states are:
+	δ: rotor angle,
+	ω: rotor speed
+- `n_states::Int64`: SingleMass has 1 state
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct SingleMass <: Shaft
@@ -27,7 +29,11 @@ mutable struct SingleMass <: Shaft
     "Rotor natural damping in pu"
     D::Float64
     ext::Dict{String, Any}
+    "The states are:
+	δ: rotor angle,
+	ω: rotor speed"
     states::Vector{Symbol}
+    "SingleMass has 1 state"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/TGFixed.jl
+++ b/src/models/generated/TGFixed.jl
@@ -19,7 +19,7 @@ Parameters of a fixed Turbine Governor that returns a fixed mechanical torque
 - `P_ref::Float64`: Reference Power Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`
-- `n_states::Int64`
+- `n_states::Int64`: TGFixed has no states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct TGFixed <: TurbineGov
@@ -29,6 +29,7 @@ mutable struct TGFixed <: TurbineGov
     P_ref::Float64
     ext::Dict{String, Any}
     states::Vector{Symbol}
+    "TGFixed has no states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/TGTypeI.jl
+++ b/src/models/generated/TGTypeI.jl
@@ -31,8 +31,11 @@ Parameters of a Turbine Governor Type I.
 - `P_max::Float64`: Max Power into the Governor, validation range: (0, nothing)
 - `P_ref::Float64`: Reference Power Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states of the TGTypeI model are:
+	x_g1: Governor state,
+	x_g2: Servo state,
+	x_g3: Reheat state
+- `n_states::Int64`: TGTypeI has 3 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct TGTypeI <: TurbineGov
@@ -55,7 +58,12 @@ mutable struct TGTypeI <: TurbineGov
     "Reference Power Set-point"
     P_ref::Float64
     ext::Dict{String, Any}
+    "The states of the TGTypeI model are:
+	x_g1: Governor state,
+	x_g2: Servo state,
+	x_g3: Reheat state"
     states::Vector{Symbol}
+    "TGTypeI has 3 states"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/TGTypeII.jl
+++ b/src/models/generated/TGTypeII.jl
@@ -25,8 +25,9 @@ Parameters of a Turbine Governor Type II.
 - `τ_max::Float64`: Max Power into the Governor, validation range: (0, nothing)
 - `P_ref::Float64`: Reference Power Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states of the TGTypeI model are:
+	x_g1: lead-lag state
+- `n_states::Int64`: TGTypeII has 1 state
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct TGTypeII <: TurbineGov
@@ -43,7 +44,10 @@ mutable struct TGTypeII <: TurbineGov
     "Reference Power Set-point"
     P_ref::Float64
     ext::Dict{String, Any}
+    "The states of the TGTypeI model are:
+	x_g1: lead-lag state"
     states::Vector{Symbol}
+    "TGTypeII has 1 state"
     n_states::Int64
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal

--- a/src/models/generated/VirtualInertia.jl
+++ b/src/models/generated/VirtualInertia.jl
@@ -20,8 +20,10 @@ Parameters of a Virtual Inertia with SRF using VSM for active power controller
 - `kω::Float64`: frequency droop gain, validation range: (0, nothing)
 - `P_ref::Float64`: Reference Power Set-point, validation range: (0, nothing)
 - `ext::Dict{String, Any}`
-- `states::Vector{Symbol}`
-- `n_states::Int64`
+- `states::Vector{Symbol}`: The states of the VirtualInertia model are:
+	ω_oc: Speed of the rotating reference frame of the virtual synchronous generator model,
+	θ_oc: Phase angle displacement of the virtual synchronous generator model
+- `n_states::Int64`: VirtualInertia has two states
 """
 mutable struct VirtualInertia <: ActivePowerControl
     "VSM inertia constant"
@@ -33,7 +35,11 @@ mutable struct VirtualInertia <: ActivePowerControl
     "Reference Power Set-point"
     P_ref::Float64
     ext::Dict{String, Any}
+    "The states of the VirtualInertia model are:
+	ω_oc: Speed of the rotating reference frame of the virtual synchronous generator model,
+	θ_oc: Phase angle displacement of the virtual synchronous generator model"
     states::Vector{Symbol}
+    "VirtualInertia has two states"
     n_states::Int64
 end
 

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -248,6 +248,7 @@ export get_start_time_limits
 export get_start_types
 export get_startup
 export get_states
+export get_states_types
 export get_status
 export get_storage_capacity
 export get_tap
@@ -454,6 +455,7 @@ export set_start_time_limits!
 export set_start_types!
 export set_startup!
 export set_states!
+export set_states_types!
 export set_status!
 export set_storage_capacity!
 export set_tap!


### PR DESCRIPTION
The following PR creates a new `StateTypes scoped_enum` and add new field to determine if a specific state could be Differential, Algebraic or Hybrid (that is, could be any of previous two depending on parameter values). We could probably use another word instead of Hybrid?

For now, only for AVR is created, since those are the cases on when it could happen, but maybe we could be interested in adding for any dynamic model struct to be consistent. The modified AVR structs are:
```
AVRFixed
AVRSimple
AVRTypeI
AVRTypeII
AC1A
ModifiedAC1A
ST1A
```

In addition, all dynamic models are now updated with docstring for state descriptions, addressing #506. Those structs didn't change their fields.