### PR TITLE
Add Impedance source in ext when parsing RAW files

### DIFF
--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -196,6 +196,8 @@ function _psse2pm_generator!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             sub_data["pmax"] = pop!(gen, "PT")
             sub_data["qmin"] = pop!(gen, "QB")
             sub_data["qmax"] = pop!(gen, "QT")
+            sub_data["r_source"] = pop!(gen, "ZR")
+            sub_data["x_source"] = pop!(gen, "ZX")
 
             # Default Cost functions
             sub_data["model"] = 2

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -364,8 +364,7 @@ function make_thermal_gen(gen_name::AbstractString, d::Dict, bus::Bus, sys_mbase
 
     ext = Dict{String, Any}()
     if haskey(d, "r_source")
-        ext["r_source"] = d["r_source"]
-        ext["x_source"] = d["x_source"]
+        ext["z_source"] = (r = d["r_source"], x = d["x_source"])
     end
 
     thermal_gen = ThermalStandard(

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -362,6 +362,12 @@ function make_thermal_gen(gen_name::AbstractString, d::Dict, bus::Bus, sys_mbase
     op_cost =
         ThreePartCost(; variable = cost, fixed = fixed, startup = startup, shutdn = shutdn)
 
+    ext = Dict{String, Any}()
+    if haskey(d, "r_source")
+        ext["r_source"] = d["r_source"]
+        ext["x_source"] = d["x_source"]
+    end
+
     thermal_gen = ThermalStandard(
         name = gen_name,
         status = Bool(d["gen_status"]),
@@ -378,6 +384,7 @@ function make_thermal_gen(gen_name::AbstractString, d::Dict, bus::Bus, sys_mbase
         timelimits = nothing,
         op_cost = op_cost,
         basepower = d["mbase"] / sys_mbase,
+        ext = ext,
     )
 
     return thermal_gen

--- a/test/test_parse_psse.jl
+++ b/test/test_parse_psse.jl
@@ -9,6 +9,9 @@
         pm_data = PowerSystems.PowerModelsData(joinpath(PSSE_RAW_DIR, f))
         @info "Successfully parsed $f to PowerModelsData"
         sys = System(pm_data)
+        for g in get_components(Generator, sys)
+            @test haskey(get_ext(g), "z_source")
+        end
         @info "Successfully parsed $f to System struct"
     end
 
@@ -28,6 +31,9 @@ end
     for f in files[1:1]
         @info "Parsing $f ..."
         sys = System(joinpath(PM_PSSE_PATH, f))
+        for g in get_components(Generator, sys)
+            @test haskey(get_ext(g), "z_source")
+        end
         @info "Successfully parsed $f to System struct"
     end
 end


### PR DESCRIPTION
The following PR adds in the ext of the parsed generators the value of R_source and X_source. These values are necessary to run dynamic simulations.