### PR TITLE
Update Source and Fix some typos

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -1308,7 +1308,9 @@ function check_component_addition(sys::System, dyn_branch::DynamicBranch)
         name = get_name(dyn_branch.branch)
         throw(ArgumentError("static branch $name is not part of the system"))
     end
-    check_component_addition(sys, dyn_branch)
+    arc = get_arc(dyn_branch)
+    check_bus(sys, get_from(arc), arc)
+    check_bus(sys, get_to(arc), arc)
 end
 
 function check_component_addition(sys::System, bus::Bus)

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -6329,24 +6329,52 @@
           "data_type": "Bus"
         },
         {
-          "name": "activepower",
+          "name": "active_power",
           "null_value": "0.0",
           "data_type": "Float64"
         },
         {
-          "name": "reactivepower",
+          "name": "reactive_power",
           "null_value": "0.0",
           "data_type": "Float64"
         },
         {
-          "name": "X_th",
-          "comment": "Source Thevenin impedance",
+          "name": "R_th",
+          "comment": "Source Thevenin resistance",
           "null_value": 0,
           "data_type": "Float64",
           "valid_range": {
             "min": 0,
             "max": null
           }
+        },
+        {
+          "name": "X_th",
+          "comment": "Source Thevenin reactance",
+          "null_value": 0,
+          "data_type": "Float64",
+          "valid_range": {
+            "min": 0,
+            "max": null
+          }
+        },
+        {
+          "name": "internal_voltage",
+          "comment": "Internal Voltage",
+          "null_value": 0,
+          "data_type": "Float64",
+          "valid_range": {
+            "min": 0,
+            "max": null
+          },
+          "default": "1.0"
+        },
+        {
+          "name": "internal_angle",
+          "comment": "Internal Angle",
+          "null_value": 0,
+          "data_type": "Float64",
+          "default": "0.0"
         },
         {
           "name": "services",

--- a/src/models/dynamic_branch.jl
+++ b/src/models/dynamic_branch.jl
@@ -13,3 +13,25 @@ mutable struct DynamicBranch <: ACBranch
         new(branch, n_states, states, IS.InfrastructureSystemsInternal())
     end
 end
+
+function DynamicBranch(; branch)
+    DynamicBranch(branch)
+end
+
+function DynamicBranch(::Nothing)
+    DynamicBranch(Line(nothing))
+end
+
+"Get branch"
+get_branch(value::DynamicBranch) = value.branch
+"Get n_states"
+get_n_states(value::DynamicBranch) = value.n_states
+"Get states"
+get_states(value::DynamicBranch) = value.states
+
+"Set branch"
+set_branch!(value::DynamicBranch, val::ACBranch) = value.branch = val
+"Set n_states"
+set_n_states!(value::DynamicBranch, val::Int64) = value.n_states = val
+"Set states"
+set_states!(value::DynamicBranch, val::Vector{Symbol}) = value.states = val

--- a/src/models/dynamic_inverter.jl
+++ b/src/models/dynamic_inverter.jl
@@ -129,4 +129,3 @@ get_static_injector(device::DynamicInverter) = device.static_injector
 get_internal(device::DynamicInverter) = device.internal
 get_P_ref(value::DynamicInverter) = get_P_ref(get_active_power(get_outer_control(value)))
 get_V_ref(value::DynamicInverter) = get_V_ref(get_reactive_power(get_outer_control(value)))
-get_V_ref(value::DynamicInverter) = get_V_ref(get_reactive_power(get_outer_control(value)))

--- a/src/models/dynamic_machines.jl
+++ b/src/models/dynamic_machines.jl
@@ -319,16 +319,19 @@ get_saturation_coeffs(value::SalientPoleExponential) = value.saturation_coeffs
 get_saturation_coeffs(value::RoundRotorQuadratic) = value.saturation_coeffs
 get_saturation_coeffs(value::RoundRotorExponential) = value.saturation_coeffs
 
-set_base_machine!(value::SalientPoleQuadratic, val::SalientPoleMachine) = value.base_machine
+set_base_machine!(value::SalientPoleQuadratic, val::SalientPoleMachine) =
+    value.base_machine = val
 set_base_machine!(value::SalientPoleExponential, val::SalientPoleMachine) =
-    value.base_machine
-set_base_machine!(value::RoundRotorQuadratic, val::RoundRotorMachine) = value.base_machine
-set_base_machine!(value::RoundRotorExponential, val::RoundRotorMachine) = value.base_machine
+    value.base_machine = val
+set_base_machine!(value::RoundRotorQuadratic, val::RoundRotorMachine) =
+    value.base_machine = val
+set_base_machine!(value::RoundRotorExponential, val::RoundRotorMachine) =
+    value.base_machine = val
 set_saturation_coeffs!(value::SalientPoleQuadratic, val::Tuple{Float64, Float64}) =
-    value.saturation_coeffs
+    value.saturation_coeffs = val
 set_saturation_coeffs!(value::SalientPoleExponential, val::Tuple{Float64, Float64}) =
-    value.saturation_coeffs
+    value.saturation_coeffs = val
 set_saturation_coeffs!(value::RoundRotorQuadratic, val::Tuple{Float64, Float64}) =
-    value.saturation_coeffs
+    value.saturation_coeffs = val
 set_saturation_coeffs!(value::RoundRotorExponential, val::Tuple{Float64, Float64}) =
-    value.saturation_coeffs
+    value.saturation_coeffs = val

--- a/src/models/generated/Source.jl
+++ b/src/models/generated/Source.jl
@@ -6,9 +6,12 @@ This file is auto-generated. Do not edit.
         name::String
         available::Bool
         bus::Bus
-        activepower::Float64
-        reactivepower::Float64
+        active_power::Float64
+        reactive_power::Float64
+        R_th::Float64
         X_th::Float64
+        internal_voltage::Float64
+        internal_angle::Float64
         services::Vector{Service}
         ext::Dict{String, Any}
         internal::InfrastructureSystemsInternal
@@ -20,9 +23,12 @@ This struct acts as an infinity bus.
 - `name::String`
 - `available::Bool`
 - `bus::Bus`
-- `activepower::Float64`
-- `reactivepower::Float64`
-- `X_th::Float64`: Source Thevenin impedance, validation range: (0, nothing)
+- `active_power::Float64`
+- `reactive_power::Float64`
+- `R_th::Float64`: Source Thevenin resistance, validation range: (0, nothing)
+- `X_th::Float64`: Source Thevenin reactance, validation range: (0, nothing)
+- `internal_voltage::Float64`: Internal Voltage, validation range: (0, nothing)
+- `internal_angle::Float64`: Internal Angle
 - `services::Vector{Service}`: Services that this device contributes to
 - `ext::Dict{String, Any}`
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
@@ -31,10 +37,16 @@ mutable struct Source <: StaticInjection
     name::String
     available::Bool
     bus::Bus
-    activepower::Float64
-    reactivepower::Float64
-    "Source Thevenin impedance"
+    active_power::Float64
+    reactive_power::Float64
+    "Source Thevenin resistance"
+    R_th::Float64
+    "Source Thevenin reactance"
     X_th::Float64
+    "Internal Voltage"
+    internal_voltage::Float64
+    "Internal Angle"
+    internal_angle::Float64
     "Services that this device contributes to"
     services::Vector{Service}
     ext::Dict{String, Any}
@@ -42,12 +54,12 @@ mutable struct Source <: StaticInjection
     internal::InfrastructureSystemsInternal
 end
 
-function Source(name, available, bus, activepower, reactivepower, X_th, services=Device[], ext=Dict{String, Any}(), )
-    Source(name, available, bus, activepower, reactivepower, X_th, services, ext, InfrastructureSystemsInternal(), )
+function Source(name, available, bus, active_power, reactive_power, R_th, X_th, internal_voltage=1.0, internal_angle=0.0, services=Device[], ext=Dict{String, Any}(), )
+    Source(name, available, bus, active_power, reactive_power, R_th, X_th, internal_voltage, internal_angle, services, ext, InfrastructureSystemsInternal(), )
 end
 
-function Source(; name, available, bus, activepower, reactivepower, X_th, services=Device[], ext=Dict{String, Any}(), )
-    Source(name, available, bus, activepower, reactivepower, X_th, services, ext, )
+function Source(; name, available, bus, active_power, reactive_power, R_th, X_th, internal_voltage=1.0, internal_angle=0.0, services=Device[], ext=Dict{String, Any}(), )
+    Source(name, available, bus, active_power, reactive_power, R_th, X_th, internal_voltage, internal_angle, services, ext, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -56,9 +68,12 @@ function Source(::Nothing)
         name="init",
         available=false,
         bus=Bus(nothing),
-        activepower=0.0,
-        reactivepower=0.0,
+        active_power=0.0,
+        reactive_power=0.0,
+        R_th=0,
         X_th=0,
+        internal_voltage=0,
+        internal_angle=0,
         services=Device[],
         ext=Dict{String, Any}(),
     )
@@ -70,12 +85,18 @@ InfrastructureSystems.get_name(value::Source) = value.name
 get_available(value::Source) = value.available
 """Get Source bus."""
 get_bus(value::Source) = value.bus
-"""Get Source activepower."""
-get_activepower(value::Source) = value.activepower
-"""Get Source reactivepower."""
-get_reactivepower(value::Source) = value.reactivepower
+"""Get Source active_power."""
+get_active_power(value::Source) = value.active_power
+"""Get Source reactive_power."""
+get_reactive_power(value::Source) = value.reactive_power
+"""Get Source R_th."""
+get_R_th(value::Source) = value.R_th
 """Get Source X_th."""
 get_X_th(value::Source) = value.X_th
+"""Get Source internal_voltage."""
+get_internal_voltage(value::Source) = value.internal_voltage
+"""Get Source internal_angle."""
+get_internal_angle(value::Source) = value.internal_angle
 """Get Source services."""
 get_services(value::Source) = value.services
 """Get Source ext."""
@@ -89,12 +110,18 @@ InfrastructureSystems.set_name!(value::Source, val::String) = value.name = val
 set_available!(value::Source, val::Bool) = value.available = val
 """Set Source bus."""
 set_bus!(value::Source, val::Bus) = value.bus = val
-"""Set Source activepower."""
-set_activepower!(value::Source, val::Float64) = value.activepower = val
-"""Set Source reactivepower."""
-set_reactivepower!(value::Source, val::Float64) = value.reactivepower = val
+"""Set Source active_power."""
+set_active_power!(value::Source, val::Float64) = value.active_power = val
+"""Set Source reactive_power."""
+set_reactive_power!(value::Source, val::Float64) = value.reactive_power = val
+"""Set Source R_th."""
+set_R_th!(value::Source, val::Float64) = value.R_th = val
 """Set Source X_th."""
 set_X_th!(value::Source, val::Float64) = value.X_th = val
+"""Set Source internal_voltage."""
+set_internal_voltage!(value::Source, val::Float64) = value.internal_voltage = val
+"""Set Source internal_angle."""
+set_internal_angle!(value::Source, val::Float64) = value.internal_angle = val
 """Set Source services."""
 set_services!(value::Source, val::Vector{Service}) = value.services = val
 """Set Source ext."""

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -116,6 +116,7 @@ export get_R
 export get_R_1d
 export get_R_1q
 export get_R_f
+export get_R_th
 export get_Se
 export get_T1
 export get_T2
@@ -160,7 +161,6 @@ export get_active_power_flow
 export get_active_power_limits
 export get_active_power_limits_from
 export get_active_power_limits_to
-export get_activepower
 export get_angle
 export get_angle_limits
 export get_arc
@@ -188,6 +188,8 @@ export get_initial_energy
 export get_initial_storage
 export get_input_active_power_limits
 export get_internal
+export get_internal_angle
+export get_internal_voltage
 export get_inv_d_fluxlink
 export get_inv_q_fluxlink
 export get_inverter_firing_angle
@@ -238,7 +240,6 @@ export get_reactive_power_flow
 export get_reactive_power_limits
 export get_reactive_power_limits_from
 export get_reactive_power_limits_to
-export get_reactivepower
 export get_rectifier_firing_angle
 export get_rectifier_tap_limits
 export get_rectifier_xrc
@@ -328,6 +329,7 @@ export set_R!
 export set_R_1d!
 export set_R_1q!
 export set_R_f!
+export set_R_th!
 export set_Se!
 export set_T1!
 export set_T2!
@@ -372,7 +374,6 @@ export set_active_power_flow!
 export set_active_power_limits!
 export set_active_power_limits_from!
 export set_active_power_limits_to!
-export set_activepower!
 export set_angle!
 export set_angle_limits!
 export set_arc!
@@ -400,6 +401,8 @@ export set_initial_energy!
 export set_initial_storage!
 export set_input_active_power_limits!
 export set_internal!
+export set_internal_angle!
+export set_internal_voltage!
 export set_inv_d_fluxlink!
 export set_inv_q_fluxlink!
 export set_inverter_firing_angle!
@@ -450,7 +453,6 @@ export set_reactive_power_flow!
 export set_reactive_power_limits!
 export set_reactive_power_limits_from!
 export set_reactive_power_limits_to!
-export set_reactivepower!
 export set_rectifier_firing_angle!
 export set_rectifier_tap_limits!
 export set_rectifier_xrc!

--- a/src/utils/power_flow/power_flow.jl
+++ b/src/utils/power_flow/power_flow.jl
@@ -103,8 +103,8 @@ Updates the flow on the branches
 function _update_branch_flow!(sys::System)
     for b in get_components(ACBranch, sys)
         S_flow = flow_val(b)
-        set_activepower_flow!(b, real(S_flow))
-        set_reactivepower_flow!(b, imag(S_flow))
+        set_active_power_flow!(b, real(S_flow))
+        set_reactive_power_flow!(b, imag(S_flow))
     end
 end
 
@@ -144,8 +144,8 @@ function _write_pf_sol!(sys::System, nl_result)
             injection = get_components(StaticInjection, sys)
             devices = [d for d in injection if d.bus == bus && !isa(d, ElectricLoad)]
             generator = devices[1]
-            generator.active_power = P_gen
-            generator.reactive_power = Q_gen
+            set_active_power!(generator, P_gen)
+            set_reactive_power!(generator, Q_gen)
         elseif bus.bustype == BusTypes.PV
             Q_gen = result[2 * ix - 1]
             θ = result[2 * ix]
@@ -153,14 +153,14 @@ function _write_pf_sol!(sys::System, nl_result)
             devices = [d for d in injection_components if d.bus == bus]
             if length(devices) == 1
                 generator = devices[1]
-                generator.reactive_power = Q_gen
+                set_reactive_power!(generator, Q_gen)
             end
             bus.angle = θ
         elseif bus.bustype == BusTypes.PQ
             Vm = result[2 * ix - 1]
             θ = result[2 * ix]
-            bus.magnitude = Vm
-            bus.angle = θ
+            set_magnitude!(bus, Vm)
+            set_angle!(bus, θ)
         end
     end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -20,5 +20,5 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
-InfrastructureSystems = "~0.11"
+InfrastructureSystems = "~0.12"
 julia = "^1.2"


### PR DESCRIPTION
The following PR updates the Source struct to replace `activepower` with `active_power` and `reactivepower` with `reactive_power` as the new convention. It also add a Thevenin resistance, and includes a internal voltage and angle with default values that will be used for dynamic purposes. I also updated the test `Project.toml` file, to include `IS@0.12`.

In addition, I fix some problems with the set functions of RoundRotor Machines, and create the get and set functions for the DynamicBranch. However, there is a StackOverFlow problem with the `add_component!` with DynamicLines, detected in the `powerflow` test (Line 77). Any ideas here? This is the stacktrace:
```
test_powerflow: test set: Error During Test at /Users/rhenriquez/.julia/dev/PowerSystems/test/test_powerflow.jl:59
  Got exception outside of a @test
  StackOverflowError:
  Stacktrace:
   [1] get_component(::Type{Line}, ::InfrastructureSystems.Components, ::String) at /Users/rhenriquez/.julia/packages/InfrastructureSystems/CXdc4/src/components.jl:167
   [2] get_component at /Users/rhenriquez/.julia/packages/InfrastructureSystems/CXdc4/src/system_data.jl:666 [inlined]
   [3] get_component at /Users/rhenriquez/.julia/dev/PowerSystems/src/base.jl:568 [inlined]
   [4] is_attached(::Line, ::System) at /Users/rhenriquez/.julia/dev/PowerSystems/src/base.jl:638
   [5] check_component_addition(::System, ::DynamicBranch) at /Users/rhenriquez/.julia/dev/PowerSystems/src/base.jl:1307
   [6] check_component_addition(::System, ::DynamicBranch) at /Users/rhenriquez/.julia/dev/PowerSystems/src/base.jl:1311 (repeats 74720 times)
   [7] add_component!(::System, ::DynamicBranch; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /Users/rhenriquez/.julia/dev/PowerSystems/src/base.jl:371
   [8] add_component!(::System, ::DynamicBranch) at /Users/rhenriquez/.julia/dev/PowerSystems/src/base.jl:369
   [9] top-level scope at /Users/rhenriquez/.julia/dev/PowerSystems/test/test_powerflow.jl:77
   [10] top-level scope at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1113
   [11] top-level scope at /Users/rhenriquez/.julia/dev/PowerSystems/test/test_powerflow.jl:61
   [12] include(::String) at ./client.jl:439
   [13] macro expansion at /Users/rhenriquez/.julia/dev/PowerSystems/test/runtests.jl:78 [inlined]
   [14] macro expansion at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1113 [inlined]
   [15] macro expansion at /Users/rhenriquez/.julia/dev/PowerSystems/test/runtests.jl:107 [inlined]
   [16] macro expansion at ./util.jl:175 [inlined]
   [17] (::var"#3#6"{ConsoleLogger})(::InfrastructureSystems.FileLogger) at /Users/rhenriquez/.julia/dev/PowerSystems/test/runtests.jl:106
   [18] open_file_logger(::var"#3#6"{ConsoleLogger}, ::String, ::Base.CoreLogging.LogLevel, ::String) at /Users/rhenriquez/.julia/packages/InfrastructureSystems/CXdc4/src/utils/logging.jl:127
   [19] open_file_logger(::Function, ::String, ::Base.CoreLogging.LogLevel) at /Users/rhenriquez/.julia/packages/InfrastructureSystems/CXdc4/src/utils/logging.jl:124
   [20] run_tests() at /Users/rhenriquez/.julia/dev/PowerSystems/test/runtests.jl:99
   [21] top-level scope at /Users/rhenriquez/.julia/dev/PowerSystems/test/runtests.jl:118
   [22] include(::String) at ./client.jl:439
   [23] top-level scope at none:6
   [24] eval(::Module, ::Any) at ./boot.jl:331
   [25] exec_options(::Base.JLOptions) at ./client.jl:264
   [26] _start() at ./client.jl:484
```