### PR TITLE
Add storage target and conversion factor to HydroReservoir

### DIFF
--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -1452,6 +1452,7 @@
         },
         {
           "name": "storage_capacity",
+          "comment": "Maximum storage capacity in the reservoir (units can be p.u-hr or m^3).",
           "null_value": "0.0",
           "data_type": "Float64",
           "valid_range": {
@@ -1463,6 +1464,7 @@
         },
         {
           "name": "inflow",
+          "comment": "Baseline inflow into the reservoir (units can be p.u. or m^3/hr)",
           "null_value": "0.0",
           "data_type": "Float64",
           "valid_range": {
@@ -1473,6 +1475,7 @@
         },
         {
           "name": "initial_storage",
+          "comment": "Initial storage capacity in the reservoir (units can be p.u-hr or m^3).",
           "null_value": "0.0",
           "data_type": "Float64",
           "valid_range": {
@@ -1481,6 +1484,20 @@
           },
           "validation_action": "error",
           "needs_conversion": true
+        },
+        {
+          "name": "storage_target",
+          "comment": "Storage target at the end of simulation as ratio of storage capacity.",
+          "null_value": "0.0",
+          "data_type": "Float64",
+          "default": "1.0"
+        },
+        {
+          "name": "conversion_factor",
+          "comment": "Conversion factor from flow/volume to energy: m^3 -> p.u-hr.",
+          "null_value": "0.0",
+          "data_type": "Float64",
+          "default": "1.0"
         },
         {
           "name": "services",

--- a/src/models/generated/includes.jl
+++ b/src/models/generated/includes.jl
@@ -175,6 +175,7 @@ export get_bus
 export get_bustype
 export get_cf
 export get_contributing_services
+export get_conversion_factor
 export get_delta_t
 export get_dynamic_injector
 export get_efficiency
@@ -260,6 +261,7 @@ export get_states
 export get_states_types
 export get_status
 export get_storage_capacity
+export get_storage_target
 export get_tap
 export get_time_at_status
 export get_time_frame
@@ -394,6 +396,7 @@ export set_bus!
 export set_bustype!
 export set_cf!
 export set_contributing_services!
+export set_conversion_factor!
 export set_delta_t!
 export set_dynamic_injector!
 export set_efficiency!
@@ -479,6 +482,7 @@ export set_states!
 export set_states_types!
 export set_status!
 export set_storage_capacity!
+export set_storage_target!
 export set_tap!
 export set_time_at_status!
 export set_time_frame!


### PR DESCRIPTION
Add new two parameters to deal with storage targets. A conversion factor was also added to deal with possible forecasts or data that is coming in `m^3` instead of `p.u.-hr`.