### PR TITLE
Serialize component modules

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -1208,8 +1208,9 @@ function deserialize_components!(sys::System, raw)
     component_cache = Dict{Base.UUID, Component}()
 
     # Add each type to this as we parse.
-    parsed_types = Set()
+    parsed_types = Set{Symbol}()
 
+    # TODO DT: use `any`
     function is_matching_type(x, types)
         for t in types
             x <: t && return true
@@ -1223,8 +1224,8 @@ function deserialize_components!(sys::System, raw)
         post_add_func = nothing,
     )
         for (c_type_str, components) in raw
-            c_type = get_component_type(c_type_str)
-            c_type in parsed_types && continue
+            c_type = IS.get_serialized_type(c_type_str)
+            nameof(c_type) in parsed_types && continue
             if !isnothing(skip_types) && is_matching_type(c_type, skip_types)
                 continue
             end
@@ -1239,7 +1240,7 @@ function deserialize_components!(sys::System, raw)
                     post_add_func(comp)
                 end
             end
-            push!(parsed_types, c_type)
+            push!(parsed_types, nameof(c_type))
         end
     end
 

--- a/src/models/OuterControl.jl
+++ b/src/models/OuterControl.jl
@@ -56,25 +56,6 @@ function OuterControl(;
     return OuterControl(active_power, reactive_power, ext, states, n_states)
 end
 
-function IS.deserialize(::Type{T}, data::Dict) where {T <: OuterControl}
-    @debug "deserialize OuterControl" T data
-    vals = Dict{Symbol, Any}()
-    for (field_name, field_type) in zip(fieldnames(OuterControl), fieldtypes(OuterControl))
-        val = data[string(field_name)]
-        if field_name === :active_power
-            vals[field_name] = deserialize(T.parameters[1], val)
-        elseif field_name === :reactive_power
-            vals[field_name] = deserialize(T.parameters[2], val)
-        elseif field_name === :states
-            vals[field_name] = [Symbol(x) for x in val]
-        else
-            vals[field_name] = deserialize(field_type, val)
-        end
-    end
-
-    return OuterControl(; vals...)
-end
-
 get_active_power(value::OuterControl) = value.active_power
 get_reactive_power(value::OuterControl) = value.reactive_power
 get_ext(value::OuterControl) = value.ext

--- a/src/models/dynamic_branch.jl
+++ b/src/models/dynamic_branch.jl
@@ -41,43 +41,6 @@ function DynamicBranch(::Nothing)
     DynamicBranch(Line(nothing))
 end
 
-const BRANCH_TYPE_KEY = "__branch_type"
-
-function IS.serialize(component::T) where {T <: DynamicBranch}
-    data = Dict{String, Any}()
-    for name in fieldnames(T)
-        val = getfield(component, name)
-        if name === :branch
-            # The device is not attached to the system, so serialize it and save the type.
-            data[BRANCH_TYPE_KEY] = string(typeof(val))
-        end
-        data[string(name)] = serialize_uuid_handling(val)
-    end
-
-    return data
-end
-
-function IS.deserialize(
-    ::Type{T},
-    data::Dict,
-    component_cache::Dict,
-) where {T <: DynamicBranch}
-    @debug T data
-    vals = Dict{Symbol, Any}()
-    for (field_name, field_type) in zip(fieldnames(T), fieldtypes(T))
-        val = data[string(field_name)]
-        if field_name === :branch
-            type = get_component_type(data[BRANCH_TYPE_KEY])
-            vals[field_name] = deserialize(type, val, component_cache)
-        else
-            vals[field_name] =
-                deserialize_uuid_handling(field_type, field_name, val, component_cache)
-        end
-    end
-
-    return DynamicBranch(; vals...)
-end
-
 "Get branch"
 get_branch(value::DynamicBranch) = value.branch
 "Get n_states"

--- a/src/models/operational_cost.jl
+++ b/src/models/operational_cost.jl
@@ -2,21 +2,6 @@ const VarCostArgs = Union{Float64, NTuple{2, Float64}, Vector{NTuple{2, Float64}
 
 abstract type OperationalCost <: DeviceParameter end
 
-function IS.serialize(val::T) where {T <: OperationalCost}
-    return Dict{String, Any}(
-        "value" => IS.serialize_struct(val),
-        IS.TYPE_KEY => string(T),
-    )
-end
-
-function IS.deserialize(::Type{<:OperationalCost}, data::Dict)
-    @debug "deserialize OperationalCost" data
-    return IS.deserialize_struct(
-        get_component_type(data[IS.TYPE_KEY]),
-        data["value"],
-    )
-end
-
 mutable struct VariableCost{T}
     cost::T
 end

--- a/src/models/serialization.jl
+++ b/src/models/serialization.jl
@@ -84,11 +84,6 @@ function deserialize_uuid_handling(field_type, val, component_cache)
         if field_type <: Vector
             _vals = field_type()
             for _val in val
-                if !haskey(_val, "value")
-                    @show _val
-                    @show field_type
-                    error("oops")
-                end
                 uuid = deserialize(Base.UUID, _val)
                 component = component_cache[uuid]
                 push!(_vals, component)


### PR DESCRIPTION
This PR adds support for serializing types that reside outside of PowerSystems. The serialization process adds a metadata dict to each component dict that includes module and type information.

This requires https://github.com/NREL-SIIP/InfrastructureSystems.jl/pull/122 and so tests will fail.