### PR TITLE
Add add_time_series! method that accepts multiple components

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -188,6 +188,8 @@ export TimeSeriesData
 export Deterministic
 export Probabilistic
 export Scenarios
+export NormalizationFactor
+export NormalizationTypes
 
 export get_dynamic_components
 
@@ -332,6 +334,8 @@ import InfrastructureSystems:
     serialize,
     deserialize,
     get_time_series_multiple,
+    NormalizationFactor,
+    NormalizationTypes,
     UnitSystem,
     SystemUnitsSettings
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -775,7 +775,7 @@ function _get_buses(data::IS.SystemData, aggregator::T) where {T <: AggregationT
 end
 
 """
-Add time series data to the system.
+Add time series data to a component.
 
 Throws ArgumentError if the component is not stored in the system.
 
@@ -785,51 +785,15 @@ function add_time_series!(sys::System, component::Component, time_series::TimeSe
 end
 
 """
-Add time series data to a system from a CSV file.
+Add the same time series data to multiple components.
 
-See InfrastructureSystems.TimeSeriesFileMetadata for description of
-normalization_factor.
-"""
-function add_time_series!(
-    sys::System,
-    filename::AbstractString,
-    component::Component,
-    label::AbstractString;
-    normalization_factor::Union{String, Float64} = 1.0,
-    scaling_factor_multiplier::Union{Nothing, Function} = nothing,
-)
-    return IS.add_time_series!(
-        sys.data,
-        filename,
-        component,
-        label;
-        normalization_factor = normalization_factor,
-        scaling_factor_multiplier = scaling_factor_multiplier,
-    )
-end
+This is significantly more efficent than calling add_time_series! for each component
+individually with the same data because in this case, only one time series array is stored.
 
+Throws ArgumentError if a component is not stored in the system.
 """
-Add a time series data to a system from a TimeSeries.TimeArray or DataFrames.DataFrame.
-
-See InfrastructureSystems.TimeSeriesFileMetadata for description of
-normalization_factor.
-"""
-function add_time_series!(
-    sys::System,
-    data::Union{TimeSeries.TimeArray, DataFrames.DataFrame},
-    component,
-    label;
-    normalization_factor::Union{String, Float64} = 1.0,
-    scaling_factor_multiplier::Union{Nothing, Function} = nothing,
-)
-    return IS.add_time_series!(
-        sys.data,
-        data,
-        component,
-        label,
-        normalization_factor = normalization_factor,
-        scaling_factor_multiplier = scaling_factor_multiplier,
-    )
+function add_time_series!(sys::System, components, time_series::TimeSeriesData)
+    return IS.add_time_series!(sys.data, components, time_series)
 end
 
 """

--- a/src/parsers/TAMU_data.jl
+++ b/src/parsers/TAMU_data.jl
@@ -93,16 +93,15 @@ function TamuSystem(tamu_folder::AbstractString; kwargs...)
             Symbol("Total Mvar Load"),
         ],
     )
-        c = get_component(PowerLoad, sys, string(lname))
-        if !isnothing(c)
-            add_time_series!(
-                sys,
-                loads[!, ["timestamp", lname]],
-                c,
-                "max_active_power";
+        component = get_component(PowerLoad, sys, string(lname))
+        if !isnothing(component)
+            ts = Deterministic(
+                "max_active_power",
+                loads[!, ["timestamp", lname]];
                 normalization_factor = Float64(maximum(loads[!, lname])),
                 scaling_factor_multiplier = get_max_active_power,
             )
+            add_time_series!(sys, component, ts)
         end
     end
 

--- a/src/parsers/pm_io/psse.jl
+++ b/src/parsers/pm_io/psse.jl
@@ -138,10 +138,12 @@ function _psse2pm_branch!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             sub_data["br_r"] = pop!(branch, "R")
             sub_data["br_x"] = pop!(branch, "X")
             sub_data["g_fr"] = pop!(branch, "GI")
-            sub_data["b_fr"] = branch["BI"] == 0.0 && branch["B"] != 0.0 ? branch["B"] / 2 :
+            sub_data["b_fr"] =
+                branch["BI"] == 0.0 && branch["B"] != 0.0 ? branch["B"] / 2 :
                 pop!(branch, "BI")
             sub_data["g_to"] = pop!(branch, "GJ")
-            sub_data["b_to"] = branch["BJ"] == 0.0 && branch["B"] != 0.0 ? branch["B"] / 2 :
+            sub_data["b_to"] =
+                branch["BJ"] == 0.0 && branch["B"] != 0.0 ? branch["B"] / 2 :
                 pop!(branch, "BJ")
             sub_data["rate_a"] = pop!(branch, "RATEA")
             sub_data["rate_b"] = pop!(branch, "RATEB")
@@ -650,7 +652,8 @@ function _psse2pm_dcline!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             sub_data = Dict{String, Any}()
 
             # Unit conversions?
-            power_demand = dcline["MDC"] == 1 ? abs(dcline["SETVL"]) :
+            power_demand =
+                dcline["MDC"] == 1 ? abs(dcline["SETVL"]) :
                 dcline["MDC"] == 2 ? abs(dcline["SETVL"] / pop!(dcline, "VSCHD") / 1000) : 0
 
             sub_data["f_bus"] = dcline["IPR"]
@@ -724,9 +727,10 @@ function _psse2pm_dcline!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             # VSC intended to be one or bi-directional?
             sub_data["f_bus"] = pop!(dcside, "IBUS")
             sub_data["t_bus"] = pop!(acside, "IBUS")
-            sub_data["br_status"] = pop!(dcline, "MDC") == 0 ||
-            pop!(dcside, "TYPE") == 0 ||
-            pop!(acside, "TYPE") == 0 ?
+            sub_data["br_status"] =
+                pop!(dcline, "MDC") == 0 ||
+                pop!(dcside, "TYPE") == 0 ||
+                pop!(acside, "TYPE") == 0 ?
                 0 : 1
 
             sub_data["pf"] = 0.0
@@ -738,10 +742,12 @@ function _psse2pm_dcline!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             sub_data["vf"] = pop!(dcside, "MODE") == 1 ? pop!(dcside, "ACSET") : 1.0
             sub_data["vt"] = pop!(acside, "MODE") == 1 ? pop!(acside, "ACSET") : 1.0
 
-            sub_data["pmaxf"] = dcside["SMAX"] == 0.0 && dcside["IMAX"] == 0.0 ?
+            sub_data["pmaxf"] =
+                dcside["SMAX"] == 0.0 && dcside["IMAX"] == 0.0 ?
                 max(abs(dcside["MAXQ"]), abs(dcside["MINQ"])) :
                 min(pop!(dcside, "IMAX"), pop!(dcside, "SMAX"))
-            sub_data["pmaxt"] = acside["SMAX"] == 0.0 && acside["IMAX"] == 0.0 ?
+            sub_data["pmaxt"] =
+                acside["SMAX"] == 0.0 && acside["IMAX"] == 0.0 ?
                 max(abs(acside["MAXQ"]), abs(acside["MINQ"])) :
                 min(pop!(acside, "IMAX"), pop!(acside, "SMAX"))
             sub_data["pminf"] = -sub_data["pmaxf"]

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -301,7 +301,8 @@ Add buses and areas to the System from the raw data.
 function bus_csv_parser!(sys::System, data::PowerSystemTableData)
     for bus in iterate_rows(data, BUS::InputCategory)
         name = bus.name
-        bus_type = isnothing(bus.bus_type) ? nothing :
+        bus_type =
+            isnothing(bus.bus_type) ? nothing :
             get_enum_value(BusTypes.BusType, bus.bus_type)
         voltage_limits = make_minmaxlimits(bus.voltage_limits_min, bus.voltage_limits_max)
 
@@ -662,7 +663,8 @@ function services_csv_parser!(sys::System, data::PowerSystemTableData)
                 bus_ids = buses[!, bus_id_column]
                 gen_type =
                     get_generator_type(gen.fuel, gen.unit_type, data.generator_mapping)
-                name = gen_type <: Storage ? get_storage_by_generator(data, gen.name).name :
+                name =
+                    gen_type <: Storage ? get_storage_by_generator(data, gen.name).name :
                     gen.name
                 sys_gen = get_component(
                     get_generator_type(gen.fuel, gen.unit_type, data.generator_mapping),
@@ -850,7 +852,8 @@ function make_timelimits(gen, up_column::Symbol, down_column::Symbol)
     down_time = get(gen, down_column, nothing)
     down_time = typeof(down_time) == String ? tryparse(Float64, down_time) : down_time
 
-    timelimits = isnothing(up_time) && isnothing(down_time) ? nothing :
+    timelimits =
+        isnothing(up_time) && isnothing(down_time) ? nothing :
         (up = up_time, down = down_time)
     return timelimits
 end
@@ -926,7 +929,8 @@ function make_thermal_generator_multistart(
         var_cost =
             VariableCost([(c - no_load_cost, pp - var_cost[1][2]) for (c, pp) in var_cost])
     end
-    lag_hot = isnothing(gen.hot_start_time) ? get_time_limits(thermal_gen).down :
+    lag_hot =
+        isnothing(gen.hot_start_time) ? get_time_limits(thermal_gen).down :
         gen.hot_start_time
     lag_warm = isnothing(gen.warm_start_time) ? 0.0 : gen.warm_start_time
     lag_cold = isnothing(gen.cold_start_time) ? 0.0 : gen.cold_start_time
@@ -1118,7 +1122,7 @@ function make_storage(data::PowerSystemTableData, gen, storage, bus)
     output_active_power_limits = (
         min = storage.output_active_power_limit_min,
         max = isnothing(storage.output_active_power_limit_max) ?
-                  gen.active_power_limits_max : storage.output_active_power_limit_max,
+              gen.active_power_limits_max : storage.output_active_power_limit_max,
     )
     efficiency = (in = storage.input_efficiency, out = storage.output_efficiency)
     (reactive_power, reactive_power_limits) = make_reactive_params(storage)

--- a/src/utils/IO/system_checks.jl
+++ b/src/utils/IO/system_checks.jl
@@ -83,7 +83,8 @@ Checks the system for sum(generator ratings) >= sum(load ratings).
 function total_load_rating(sys::System)
     base_power = get_base_power(sys)
     controllable_loads = get_components(ControllableLoad, sys)
-    cl = isempty(controllable_loads) ? 0.0 :
+    cl =
+        isempty(controllable_loads) ? 0.0 :
         sum(get_max_active_power.(controllable_loads)) * base_power
     @debug "System has $cl MW of ControllableLoad"
     static_loads = get_components(StaticLoad, sys)
@@ -91,7 +92,8 @@ function total_load_rating(sys::System)
     @debug "System has $sl MW of StaticLoad"
     # Total load calculation assumes  P = Real(V^2/Y) assuming V=1.0
     fa_loads = get_components(FixedAdmittance, sys)
-    fa = isempty(fa_loads) ? 0.0 :
+    fa =
+        isempty(fa_loads) ? 0.0 :
         sum(real.(get_base_voltage.(get_bus.(fa_loads)) .^ 2 ./ get_Y.(fa_loads)))
     @debug "System has $fa MW of FixedAdmittance assuming admittancce values are in P.U."
     total_load = cl + sl + fa

--- a/test/test_power_system_table_data.jl
+++ b/test/test_power_system_table_data.jl
@@ -50,7 +50,8 @@ end
         function check_fields(chk_dat)
             for field in chk_dat.fields
                 n = get(chk_dat, :structname, nothing)
-                (cdmd, mpd) = isnothing(n) ? (cdmgen, mpgen) :
+                (cdmd, mpd) =
+                    isnothing(n) ? (cdmgen, mpgen) :
                     (getfield(cdmgen, n), getfield(mpgen, n))
                 cdmgen_val = getfield(cdmd, field)
                 mpgen_val = getfield(mpd, field)


### PR DESCRIPTION
- Remove add_time_series! method that creates Deterministic and adds in
one step. Users now need to perform this individually.
- Support new NormalizationFactor type.

This removes add_time_series! methods that constructed Deterministic
and added it to the system in one step.

This is dependent on https://github.com/NREL-SIIP/InfrastructureSystems.jl/pull/125, and so tests will fail.