### PR TITLE
Time series updates

### DIFF
--- a/docs/src/modeler/parsing.md
+++ b/docs/src/modeler/parsing.md
@@ -76,7 +76,7 @@ files. The following fields are required for each time array:
 * category:  Type of component. Must map to PowerSystems abstract types (Bus,
   ElectricLoad, Generator, LoadZone, Reserve)
 * component_name:  Name of component
-* label:  User-defined label for the time series data.
+* name:  User-defined name for the time series data.
 * normalization_factor:  Controls normalization of the data. Use 1.0 for
   pre-normalized data. Use 'Max' to divide the timeseries by the max value in the
   column. Use any float for a custom scaling factor.

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -199,7 +199,6 @@ export solve_powerflow
 
 export parse_file
 export add_time_series!
-export add_time_series_from_file_metadata!
 export remove_time_series!
 export clear_time_series!
 export copy_time_series!
@@ -332,6 +331,7 @@ import InfrastructureSystems:
     get_resolution,
     get_name,
     set_name!,
+    get_time_series,
     to_json,
     from_json,
     serialize,

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -187,6 +187,7 @@ export StateTypes
 export TimeSeriesData
 export Deterministic
 export Probabilistic
+export SingleTimeSeries
 export Scenarios
 export NormalizationFactor
 export NormalizationTypes
@@ -198,6 +199,7 @@ export solve_powerflow
 
 export parse_file
 export add_time_series!
+export add_time_series_from_file_metadata!
 export remove_time_series!
 export clear_time_series!
 export copy_time_series!
@@ -219,8 +221,6 @@ export get_contributing_device_mapping
 export ServiceContributingDevices
 export ServiceContributingDevicesKey
 export ServiceContributingDevicesMapping
-export are_time_series_contiguous
-export generate_initial_times
 export get_component
 export get_components
 export get_components_by_name
@@ -229,9 +229,9 @@ export get_time_series
 export get_time_series_array
 export get_time_series_horizon
 export get_time_series_initial_time
-export get_time_series_initial_times
+#export get_time_series_initial_times
 export get_time_series_interval
-export get_time_series_labels
+export get_time_series_names
 export get_time_series_resolution
 export get_time_series_timestamps
 export get_time_series_values
@@ -241,9 +241,10 @@ export get_resolution
 export get_data
 export iterate_components
 export get_time_series_multiple
-export make_time_series
+#export make_time_series
 export get_bus_numbers
 export get_name
+export set_name!
 export get_base_power
 export get_frequency
 export set_units_base_system!
@@ -313,6 +314,7 @@ import InfrastructureSystems:
     Components,
     Deterministic,
     Probabilistic,
+    SingleTimeSeries,
     TimeSeriesData,
     Scenarios,
     InfrastructureSystemsComponent,
@@ -329,6 +331,7 @@ import InfrastructureSystems:
     get_initial_time,
     get_resolution,
     get_name,
+    set_name!,
     to_json,
     from_json,
     serialize,

--- a/src/base.jl
+++ b/src/base.jl
@@ -415,7 +415,7 @@ function add_service!(
 end
 
 """
-Adds time series data from a metadata file or metadata descriptors.
+Add time series data from a metadata file or metadata descriptors.
 
 # Arguments
 - `sys::System`: system
@@ -423,11 +423,7 @@ Adds time series data from a metadata file or metadata descriptors.
   that includes an array of IS.TimeSeriesFileMetadata instances or a vector.
 - `resolution::DateTime.Period=nothing`: skip time series that don't match this resolution.
 """
-function add_time_series_from_file_metadata!(
-    sys::System,
-    metadata_file::AbstractString;
-    resolution = nothing,
-)
+function add_time_series!(sys::System, metadata_file::AbstractString; resolution = nothing)
     return IS.add_time_series_from_file_metadata!(
         sys.data,
         Component,
@@ -437,14 +433,14 @@ function add_time_series_from_file_metadata!(
 end
 
 """
-Adds time series data from a metadata file or metadata descriptors.
+Add time series data from a metadata file or metadata descriptors.
 
 # Arguments
 - `sys::System`: system
 - `timeseries_metadata::Vector{IS.TimeSeriesFileMetadata}`: metadata for timeseries
 - `resolution::DateTime.Period=nothing`: skip time series that don't match this resolution.
 """
-function add_time_series_from_file_metadata!(
+function add_time_series!(
     sys::System,
     file_metadata::Vector{IS.TimeSeriesFileMetadata};
     resolution = nothing,
@@ -462,7 +458,6 @@ function IS.add_time_series_from_file_metadata_internal!(
     ::Type{<:Component},
     cache::IS.TimeSeriesCache,
     file_metadata::IS.TimeSeriesFileMetadata,
-    resolution,
 )
     IS.set_component!(file_metadata, data, PowerSystems)
     component = file_metadata.component
@@ -470,11 +465,7 @@ function IS.add_time_series_from_file_metadata_internal!(
         return
     end
 
-    ts = IS.make_time_series!(cache, file_metadata, resolution)
-    if ts === nothing
-        return
-    end
-
+    ts = IS.make_time_series!(cache, file_metadata)
     if component isa Area
         uuids = Set{UUIDs.UUID}()
         for bus in _get_buses(data, component)
@@ -801,7 +792,7 @@ end
 """
 Add the same time series data to multiple components.
 
-This is significantly more efficent than calling add_time_series! for each component
+This is significantly more efficent than calling `add_time_series!` for each component
 individually with the same data because in this case, only one time series array is stored.
 
 Throws ArgumentError if a component is not stored in the system.
@@ -877,29 +868,6 @@ function make_time_series(
     return IS.make_time_series!(sys.data, metadata; resolution = resolution)
 end
 =#
-
-"""
-Return a TimeSeriesData for the entire time series range stored for these parameters.
-"""
-function get_time_series(
-    ::Type{T},
-    component::Component,
-    name::AbstractString,
-) where {T <: TimeSeriesData}
-    return IS.get_time_series(T, component, name)
-end
-
-"""
-Return a TimeSeriesData for a subset of the time series range stored for these parameters.
-"""
-function get_time_series(
-    ::Type{T},
-    component::Component,
-    name::AbstractString,
-    horizon::Int,
-) where {T <: TimeSeriesData}
-    return IS.get_time_series(T, component, name, horizon)
-end
 
 #function get_time_series_initial_times(
 #    ::Type{T},

--- a/src/parsers/TAMU_data.jl
+++ b/src/parsers/TAMU_data.jl
@@ -95,7 +95,7 @@ function TamuSystem(tamu_folder::AbstractString; kwargs...)
     )
         component = get_component(PowerLoad, sys, string(lname))
         if !isnothing(component)
-            ts = Deterministic(
+            ts = SingleTimeSeries(
                 "max_active_power",
                 loads[!, ["timestamp", lname]];
                 normalization_factor = Float64(maximum(loads[!, lname])),

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -40,10 +40,10 @@ function PowerSystemTableData(
     end
     base_power = get(data, "base_power", DEFAULT_BASE_MVA)
 
-    for (label, category) in categories
-        val = get(data, label, nothing)
+    for (name, category) in categories
+        val = get(data, name, nothing)
         if isnothing(val)
-            @debug "key '$label' not found in input data, set to nothing"
+            @debug "key '$name' not found in input data, set to nothing"
         else
             category_to_df[category] = val
         end
@@ -287,7 +287,11 @@ function System(
     )
 
     if !isnothing(timeseries_metadata_file)
-        add_time_series!(sys, timeseries_metadata_file; resolution = time_series_resolution)
+        add_time_series_from_file_metadata!(
+            sys,
+            timeseries_metadata_file;
+            resolution = time_series_resolution,
+        )
     end
 
     check!(sys)

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -287,11 +287,7 @@ function System(
     )
 
     if !isnothing(timeseries_metadata_file)
-        add_time_series_from_file_metadata!(
-            sys,
-            timeseries_metadata_file;
-            resolution = time_series_resolution,
-        )
+        add_time_series!(sys, timeseries_metadata_file; resolution = time_series_resolution)
     end
 
     check!(sys)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,6 @@ import InteractiveUtils
 import JSON3
 
 import InfrastructureSystems
-import InfrastructureSystems: Deterministic, Probabilistic, Scenarios, TimeSeriesData
 const IS = InfrastructureSystems
 using PowerSystems
 import PowerSystems: PowerSystemTableData

--- a/test/test_constructors.jl
+++ b/test/test_constructors.jl
@@ -103,21 +103,22 @@ end
         [DateTime("01-01-01"), DateTime("01-01-01") + Hour(1)],
         [1.0, 1.0],
     )
-    #Deterministic Tests
-    ts = Deterministic("scalingfactor", Hour(1), DateTime("01-01-01"), 24)
+    #SingleTimeSeries Tests
+    ts = SingleTimeSeries("scalingfactor", Hour(1), DateTime("01-01-01"), 24)
     @test ts isa PowerSystems.TimeSeriesData
-    ts = Deterministic(label = "scalingfactor", data = data)
+    ts = SingleTimeSeries(name = "scalingfactor", data = data)
     @test ts isa PowerSystems.TimeSeriesData
+    # TODO 1.0
     #Probabilistic Tests
-    ts = Probabilistic("scalingfactor", Hour(1), DateTime("01-01-01"), [0.5, 0.5], 24)
-    @test ts isa PowerSystems.TimeSeriesData
-    ts = Probabilistic(label = "scalingfactor", percentiles = [1.0], data = data)
-    @test ts isa PowerSystems.TimeSeriesData
-    #Scenario Tests
-    ts = Scenarios("scalingfactor", Hour(1), DateTime("01-01-01"), 2, 24)
-    @test ts isa PowerSystems.TimeSeriesData
-    ts = Scenarios("scalingfactor", data)
-    @test ts isa PowerSystems.TimeSeriesData
+    #ts = Probabilistic("scalingfactor", Hour(1), DateTime("01-01-01"), [0.5, 0.5], 24)
+    #@test ts isa PowerSystems.TimeSeriesData
+    #ts = Probabilistic(name = "scalingfactor", percentiles = [1.0], data = data)
+    #@test ts isa PowerSystems.TimeSeriesData
+    ##Scenario Tests
+    #ts = Scenarios("scalingfactor", Hour(1), DateTime("01-01-01"), 2, 24)
+    #@test ts isa PowerSystems.TimeSeriesData
+    #ts = Scenarios("scalingfactor", data)
+    #@test ts isa PowerSystems.TimeSeriesData
 end
 
 @testset "Regulation Device" begin

--- a/test/test_powersystemconstructors.jl
+++ b/test/test_powersystemconstructors.jl
@@ -140,16 +140,16 @@ end
     dates = collect(initial_time:Dates.Hour(1):Dates.DateTime("2020-01-01T23:00:00"))
     data = collect(1:24)
     ta = TimeSeries.TimeArray(dates, data, [get_name(l)])
-    label = "active_power_flow"
-    time_series = Deterministic(label = label, data = ta)
+    name = "active_power_flow"
+    time_series = SingleTimeSeries(name = name, data = ta)
     add_time_series!(sys, l, time_series)
-    @test get_time_series(Deterministic, l, initial_time, label) isa Deterministic
+    @test get_time_series(SingleTimeSeries, l, name) isa SingleTimeSeries
     PSY.convert_component!(MonitoredLine, l, sys)
     @test isnothing(get_component(Line, sys, "4"))
     mline = get_component(MonitoredLine, sys, "4")
     @test !isnothing(mline)
     @test get_name(mline) == "4"
-    @test get_time_series(Deterministic, mline, initial_time, label) isa Deterministic
+    @test get_time_series(SingleTimeSeries, mline, name) isa SingleTimeSeries
     @test_throws ErrorException convert_component!(
         Line,
         get_component(MonitoredLine, sys, "4"),
@@ -158,5 +158,5 @@ end
     convert_component!(Line, get_component(MonitoredLine, sys, "4"), sys, force = true)
     line = get_component(Line, sys, "4")
     @test !isnothing(mline)
-    @test get_time_series(Deterministic, line, initial_time, label) isa Deterministic
+    @test get_time_series(SingleTimeSeries, line, name) isa SingleTimeSeries
 end

--- a/test/test_read_time_series.jl
+++ b/test/test_read_time_series.jl
@@ -66,7 +66,7 @@ end
 
     # Test code path where no normalization occurs.
     sys = System(PowerSystems.PowerModelsData(joinpath(MATPOWER_DIR, "RTS_GMLC.m")))
-    add_time_series_from_file_metadata!(sys, [file_metadata])
+    add_time_series!(sys, [file_metadata])
     verify_time_series(sys, 1, 1, 24)
     time_series = collect(get_time_series_multiple(sys))[1]
     @test TimeSeries.values(time_series.data) == TimeSeries.values(timeseries)
@@ -74,7 +74,7 @@ end
     # Test code path where timeseries is normalized by dividing by the max value.
     file_metadata.normalization_factor = "Max"
     sys = System(PowerSystems.PowerModelsData(joinpath(MATPOWER_DIR, "RTS_GMLC.m")))
-    add_time_series_from_file_metadata!(sys, [file_metadata])
+    add_time_series!(sys, [file_metadata])
     verify_time_series(sys, 1, 1, 24)
     time_series = collect(get_time_series_multiple(sys))[1]
     @test TimeSeries.values(time_series.data) == TimeSeries.values(timeseries ./ max_value)
@@ -83,7 +83,7 @@ end
     nf = 95.0
     file_metadata.normalization_factor = nf
     sys = System(PowerSystems.PowerModelsData(joinpath(MATPOWER_DIR, "RTS_GMLC.m")))
-    add_time_series_from_file_metadata!(sys, [file_metadata])
+    add_time_series!(sys, [file_metadata])
     verify_time_series(sys, 1, 1, 24)
     time_series = collect(get_time_series_multiple(sys))[1]
     @test TimeSeries.values(time_series.data) == TimeSeries.values(timeseries ./ nf)
@@ -134,24 +134,21 @@ end
 @testset "TimeSeriesData data matpower" begin
     sys = System(PowerSystems.PowerModelsData(joinpath(MATPOWER_DIR, "case5_re.m")))
     file_metadata = joinpath(TIME_SERIES_DIR, "5bus_ts", "timeseries_pointers_da.json")
-    add_time_series_from_file_metadata!(sys, file_metadata)
+    add_time_series!(sys, file_metadata)
     @test verify_time_series(sys, 1, 5, 24)
 
     # Add the same files.
     # This will fail because the component-name pairs will be duplicated.
-    @test_throws ArgumentError add_time_series_from_file_metadata!(sys, file_metadata)
+    @test_throws ArgumentError add_time_series!(sys, file_metadata)
 
     file_metadata = joinpath(TIME_SERIES_DIR, "5bus_ts", "timeseries_pointers_rt.json")
 
     ## This will fail because the resolutions are different.
-    @test_throws PowerSystems.DataFormatError add_time_series_from_file_metadata!(
-        sys,
-        file_metadata,
-    )
+    @test_throws PowerSystems.DataFormatError add_time_series!(sys, file_metadata)
 
     ## TODO: need a dataset with same resolution but different horizon.
 
     sys = System(PowerSystems.PowerModelsData(joinpath(MATPOWER_DIR, "case5_re.m")))
-    add_time_series_from_file_metadata!(sys, file_metadata)
+    add_time_series!(sys, file_metadata)
     @test verify_time_series(sys, 1, 5, 288)
 end

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -47,7 +47,7 @@ end
     end_time = Dates.DateTime("2020-01-01T23:00:00")
     dates = collect(initial_time:Dates.Hour(1):end_time)
     data = collect(1:24)
-    label = "active_power"
+    name = "active_power"
     contributing_devices = Vector{Device}()
     for g in get_components(
         ThermalStandard,
@@ -58,8 +58,8 @@ end
             continue
         end
         ta = TimeSeries.TimeArray(dates, data, [Symbol(get_name(g))])
-        time_series = IS.Deterministic(
-            label = label,
+        time_series = IS.SingleTimeSeries(
+            name = name,
             data = ta,
             scaling_factor_multiplier = get_active_power,
         )
@@ -77,7 +77,7 @@ end
 
     # Ensure the time_series attached to the ThermalStandard got deserialized.
     for rd in get_components(RegulationDevice, sys2)
-        @test get_time_series(Deterministic, rd, initial_time, label) isa Deterministic
+        @test get_time_series(SingleTimeSeries, rd, name) isa SingleTimeSeries
     end
 
     clear_time_series!(sys2)

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -101,8 +101,9 @@ end
     tg = RenewableFix(nothing)
     tg.bus = bus
     add_component!(sys, tg)
-    ts = PSY.Probabilistic("scalingfactor", Hour(1), DateTime("01-01-01"), [0.5, 0.5], 24)
-    add_time_series!(sys, tg, ts)
+    # TODO 1.0
+    #ts = PSY.Probabilistic("scalingfactor", Hour(1), DateTime("01-01-01"), [0.5, 0.5], 24)
+    #add_time_series!(sys, tg, ts)
 
     _, result = validate_serialization(sys)
     @test result

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -42,42 +42,30 @@
         @test bus_number == bus.number
     end
 
-    initial_times = get_time_series_initial_times(sys)
-    @assert length(initial_times) == 1
-    initial_time = initial_times[1]
+    #initial_times = get_time_series_initial_times(sys)
+    #@assert length(initial_times) == 1
+    #initial_time = initial_times[1]
 
-    # Get time_series with a label and without.
+    # Get time_series with a name and without.
     components = collect(get_components(HydroEnergyReservoir, sys))
     @test !isempty(components)
     component = components[1]
-    ts = get_time_series(Deterministic, component, initial_time, "max_active_power")
-    @test ts isa Deterministic
+    ts = get_time_series(SingleTimeSeries, component, "max_active_power")
+    @test ts isa SingleTimeSeries
 
     # Test all versions of get_time_series_[array|timestamps|values]
     values1 = get_time_series_array(component, ts)
-    values2 =
-        get_time_series_array(Deterministic, component, initial_time, "max_active_power")
+    values2 = get_time_series_array(SingleTimeSeries, component, "max_active_power")
     @test values1 == values2
-    values3 = get_time_series_array(
-        Deterministic,
-        component,
-        initial_time,
-        "max_active_power",
-        get_horizon(ts),
-    )
+    values3 = get_time_series_array(SingleTimeSeries, component, "max_active_power")
     @test values1 == values3
 
-    val = get_time_series_array(Deterministic, component, initial_time, "max_active_power")
+    val = get_time_series_array(SingleTimeSeries, component, "max_active_power")
     @test val isa TimeSeries.TimeArray
-    val = get_time_series_timestamps(
-        Deterministic,
-        component,
-        initial_time,
-        "max_active_power",
-    )
+    val = get_time_series_timestamps(SingleTimeSeries, component, "max_active_power")
     @test val isa Array
     @test val[1] isa Dates.DateTime
-    val = get_time_series_values(Deterministic, component, initial_time, "max_active_power")
+    val = get_time_series_values(SingleTimeSeries, component, "max_active_power")
     @test val isa Array
     @test val[1] isa AbstractFloat
 
@@ -90,18 +78,13 @@
     @test val isa Array
     @test val[1] isa AbstractFloat
 
-    horizon = get_time_series_horizon(sys)
-    @test horizon == 24
-    @test get_time_series_initial_time(sys) == Dates.DateTime("2020-01-01T00:00:00")
-    @test get_time_series_interval(sys) == Dates.Hour(0)
-    resolution = get_time_series_resolution(sys)
-    @test resolution == Dates.Hour(1)
-
-    # Actual functionality is tested in InfrastructureSystems.
-    @test generate_initial_times(sys, resolution, horizon)[1] == initial_time
-    @test generate_initial_times(component, resolution, horizon)[1] == initial_time
-    @test are_time_series_contiguous(sys)
-    @test are_time_series_contiguous(component)
+    # TODO 1.0
+    #horizon = get_time_series_horizon(sys)
+    #@test horizon == 24
+    #@test get_time_series_initial_time(sys) == Dates.DateTime("2020-01-01T00:00:00")
+    #@test get_time_series_interval(sys) == Dates.Hour(0)
+    #resolution = get_time_series_resolution(sys)
+    #@test resolution == Dates.Hour(1)
 
     clear_time_series!(sys)
     @test length(collect(get_time_series_multiple(sys))) == 0
@@ -151,20 +134,20 @@ end
     components = get_components(Component, sys)
     @test i == length(components)
 
-    initial_times = get_time_series_initial_times(sys)
-    unique_initial_times = Set{Dates.DateTime}()
-    for time_series in get_time_series_multiple(sys)
-        push!(unique_initial_times, get_initial_time(time_series))
-    end
-    @test initial_times == sort!(collect(unique_initial_times))
+    #initial_times = get_time_series_initial_times(sys)
+    #unique_initial_times = Set{Dates.DateTime}()
+    #for time_series in get_time_series_multiple(sys)
+    #    push!(unique_initial_times, get_initial_time(time_series))
+    #end
+    #@test initial_times == sort!(collect(unique_initial_times))
 
-    for initial_time in initial_times
-        all_ts = collect(get_time_series_multiple(sys; initial_time = initial_time))
-        @test length(all_ts) > 0
-        for time_series in all_ts
-            @test get_initial_time(time_series) == initial_time
-        end
-    end
+    #for initial_time in initial_times
+    #    all_ts = collect(get_time_series_multiple(sys; initial_time = initial_time))
+    #    @test length(all_ts) > 0
+    #    for time_series in all_ts
+    #        @test get_initial_time(time_series) == initial_time
+    #    end
+    #end
 end
 
 @testset "Test remove_component" begin
@@ -253,13 +236,13 @@ end
     dates = collect(initial_time:Dates.Hour(1):end_time)
     data = collect(1:24)
     ta = TimeSeries.TimeArray(dates, data, ["1"])
-    label = "max_active_power"
-    ts = Deterministic(label = label, data = ta)
+    name = "max_active_power"
+    ts = SingleTimeSeries(name = name, data = ta)
     add_time_series!(sys, components, ts)
 
     for i in 1:len
         component = get_component(ThermalStandard, sys, string(i))
-        ts = get_time_series(Deterministic, component, initial_time, label)
-        @test ts isa Deterministic
+        ts = get_time_series(SingleTimeSeries, component, name)
+        @test ts isa SingleTimeSeries
     end
 end


### PR DESCRIPTION
This updates PowerSystems to with the pre-10 branch of InfrastructureSystems.  It also requires the pre-10 branch of PowerSystemsTestData.

A number of things are commented out.  Leaving this as a draft until we workout what to do with them.

All tests pass except for 
- Some in test_read_time_series.jl.  These failures are due to an interface change in IS.read_time_series.  We currently don't have a way to convert PSY-supported time series CSV files into TimeArray objects.  Leaving this unresolved until we determine whether we want to restore the prior functionality.