### PR TITLE
Remove wrong service costs

### DIFF
--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -2765,13 +2765,6 @@
           "default": "Dict{String, Any}()"
         },
         {
-          "name": "operation_cost",
-          "null_value": "TwoPartCost(nothing)",
-          "data_type": "Union{Nothing, TwoPartCost}",
-          "default": "nothing",
-          "comment": "Cost for providing reserves  [`TwoPartCost`](@ref)"
-        },
-        {
           "name": "internal",
           "comment": "power system internal reference, do not modify",
           "data_type": "InfrastructureSystemsInternal",
@@ -2823,13 +2816,6 @@
           "data_type": "Dict{String, Any}",
           "null_value": "Dict{String, Any}()",
           "default": "Dict{String, Any}()"
-        },
-        {
-          "name": "operation_cost",
-          "null_value": "TwoPartCost(nothing)",
-          "data_type": "Union{Nothing, TwoPartCost}",
-          "default": "nothing",
-          "comment": "Cost for providing reserves  [`TwoPartCost`](@ref)"
         },
         {
           "name": "internal",
@@ -2997,13 +2983,6 @@
           "default": "InfrastructureSystems.TimeSeriesContainer()"
         },
         {
-          "name": "operation_cost",
-          "null_value": "TwoPartCost(nothing)",
-          "data_type": "Union{Nothing, TwoPartCost}",
-          "default": "nothing",
-          "comment": "Cost for providing reserves  [`TwoPartCost`](@ref)"
-        },
-        {
           "name": "internal",
           "comment": "power system internal reference, do not modify",
           "data_type": "InfrastructureSystemsInternal",
@@ -3058,13 +3037,6 @@
           "null_value": "InfrastructureSystems.TimeSeriesContainer()",
           "data_type": "InfrastructureSystems.TimeSeriesContainer",
           "default": "InfrastructureSystems.TimeSeriesContainer()"
-        },
-        {
-          "name": "operation_cost",
-          "null_value": "TwoPartCost(nothing)",
-          "data_type": "Union{Nothing, TwoPartCost}",
-          "default": "nothing",
-          "comment": "Cost for providing reserves  [`TwoPartCost`](@ref)"
         },
         {
           "name": "internal",

--- a/src/models/generated/StaticReserve.jl
+++ b/src/models/generated/StaticReserve.jl
@@ -8,7 +8,6 @@ This file is auto-generated. Do not edit.
         time_frame::Float64
         requirement::Float64
         ext::Dict{String, Any}
-        operation_cost::Union{Nothing, TwoPartCost}
         internal::InfrastructureSystemsInternal
     end
 
@@ -20,7 +19,6 @@ Data Structure for a proportional reserve product for system simulations.
 - `time_frame::Float64`: the relative saturation time_frame, validation range: `(0, nothing)`, action if invalid: `error`
 - `requirement::Float64`: the static value of required reserves in system p.u., validation range: `(0, nothing)`, action if invalid: `error`
 - `ext::Dict{String, Any}`
-- `operation_cost::Union{Nothing, TwoPartCost}`: Cost for providing reserves  [`TwoPartCost`](@ref)
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct StaticReserve{T <: ReserveDirection} <: Reserve{T}
@@ -31,18 +29,16 @@ mutable struct StaticReserve{T <: ReserveDirection} <: Reserve{T}
     "the static value of required reserves in system p.u."
     requirement::Float64
     ext::Dict{String, Any}
-    "Cost for providing reserves  [`TwoPartCost`](@ref)"
-    operation_cost::Union{Nothing, TwoPartCost}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
-function StaticReserve{T}(name, available, time_frame, requirement, ext=Dict{String, Any}(), operation_cost=nothing, ) where T <: ReserveDirection
-    StaticReserve{T}(name, available, time_frame, requirement, ext, operation_cost, InfrastructureSystemsInternal(), )
+function StaticReserve{T}(name, available, time_frame, requirement, ext=Dict{String, Any}(), ) where T <: ReserveDirection
+    StaticReserve{T}(name, available, time_frame, requirement, ext, InfrastructureSystemsInternal(), )
 end
 
-function StaticReserve{T}(; name, available, time_frame, requirement, ext=Dict{String, Any}(), operation_cost=nothing, internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
-    StaticReserve{T}(name, available, time_frame, requirement, ext, operation_cost, internal, )
+function StaticReserve{T}(; name, available, time_frame, requirement, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
+    StaticReserve{T}(name, available, time_frame, requirement, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -53,7 +49,6 @@ function StaticReserve{T}(::Nothing) where T <: ReserveDirection
         time_frame=0.0,
         requirement=0.0,
         ext=Dict{String, Any}(),
-        operation_cost=TwoPartCost(nothing),
     )
 end
 
@@ -67,8 +62,6 @@ get_time_frame(value::StaticReserve) = value.time_frame
 get_requirement(value::StaticReserve) = value.requirement
 """Get [`StaticReserve`](@ref) `ext`."""
 get_ext(value::StaticReserve) = value.ext
-"""Get [`StaticReserve`](@ref) `operation_cost`."""
-get_operation_cost(value::StaticReserve) = value.operation_cost
 """Get [`StaticReserve`](@ref) `internal`."""
 get_internal(value::StaticReserve) = value.internal
 
@@ -82,6 +75,4 @@ set_time_frame!(value::StaticReserve, val) = value.time_frame = val
 set_requirement!(value::StaticReserve, val) = value.requirement = val
 """Set [`StaticReserve`](@ref) `ext`."""
 set_ext!(value::StaticReserve, val) = value.ext = val
-"""Set [`StaticReserve`](@ref) `operation_cost`."""
-set_operation_cost!(value::StaticReserve, val) = value.operation_cost = val
 

--- a/src/models/generated/StaticReserveNonSpinning.jl
+++ b/src/models/generated/StaticReserveNonSpinning.jl
@@ -8,7 +8,6 @@ This file is auto-generated. Do not edit.
         time_frame::Float64
         requirement::Float64
         ext::Dict{String, Any}
-        operation_cost::Union{Nothing, TwoPartCost}
         internal::InfrastructureSystemsInternal
     end
 
@@ -20,7 +19,6 @@ Data Structure for a non-spinning reserve product for system simulations.
 - `time_frame::Float64`: the relative saturation time_frame, validation range: `(0, nothing)`, action if invalid: `error`
 - `requirement::Float64`: the static value of required reserves in system p.u., validation range: `(0, nothing)`, action if invalid: `error`
 - `ext::Dict{String, Any}`
-- `operation_cost::Union{Nothing, TwoPartCost}`: Cost for providing reserves  [`TwoPartCost`](@ref)
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct StaticReserveNonSpinning <: ReserveNonSpinning
@@ -31,18 +29,16 @@ mutable struct StaticReserveNonSpinning <: ReserveNonSpinning
     "the static value of required reserves in system p.u."
     requirement::Float64
     ext::Dict{String, Any}
-    "Cost for providing reserves  [`TwoPartCost`](@ref)"
-    operation_cost::Union{Nothing, TwoPartCost}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
-function StaticReserveNonSpinning(name, available, time_frame, requirement, ext=Dict{String, Any}(), operation_cost=nothing, )
-    StaticReserveNonSpinning(name, available, time_frame, requirement, ext, operation_cost, InfrastructureSystemsInternal(), )
+function StaticReserveNonSpinning(name, available, time_frame, requirement, ext=Dict{String, Any}(), )
+    StaticReserveNonSpinning(name, available, time_frame, requirement, ext, InfrastructureSystemsInternal(), )
 end
 
-function StaticReserveNonSpinning(; name, available, time_frame, requirement, ext=Dict{String, Any}(), operation_cost=nothing, internal=InfrastructureSystemsInternal(), )
-    StaticReserveNonSpinning(name, available, time_frame, requirement, ext, operation_cost, internal, )
+function StaticReserveNonSpinning(; name, available, time_frame, requirement, ext=Dict{String, Any}(), internal=InfrastructureSystemsInternal(), )
+    StaticReserveNonSpinning(name, available, time_frame, requirement, ext, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -53,7 +49,6 @@ function StaticReserveNonSpinning(::Nothing)
         time_frame=0.0,
         requirement=0.0,
         ext=Dict{String, Any}(),
-        operation_cost=TwoPartCost(nothing),
     )
 end
 
@@ -67,8 +62,6 @@ get_time_frame(value::StaticReserveNonSpinning) = value.time_frame
 get_requirement(value::StaticReserveNonSpinning) = value.requirement
 """Get [`StaticReserveNonSpinning`](@ref) `ext`."""
 get_ext(value::StaticReserveNonSpinning) = value.ext
-"""Get [`StaticReserveNonSpinning`](@ref) `operation_cost`."""
-get_operation_cost(value::StaticReserveNonSpinning) = value.operation_cost
 """Get [`StaticReserveNonSpinning`](@ref) `internal`."""
 get_internal(value::StaticReserveNonSpinning) = value.internal
 
@@ -82,6 +75,4 @@ set_time_frame!(value::StaticReserveNonSpinning, val) = value.time_frame = val
 set_requirement!(value::StaticReserveNonSpinning, val) = value.requirement = val
 """Set [`StaticReserveNonSpinning`](@ref) `ext`."""
 set_ext!(value::StaticReserveNonSpinning, val) = value.ext = val
-"""Set [`StaticReserveNonSpinning`](@ref) `operation_cost`."""
-set_operation_cost!(value::StaticReserveNonSpinning, val) = value.operation_cost = val
 

--- a/src/models/generated/VariableReserve.jl
+++ b/src/models/generated/VariableReserve.jl
@@ -9,7 +9,6 @@ This file is auto-generated. Do not edit.
         requirement::Float64
         ext::Dict{String, Any}
         time_series_container::InfrastructureSystems.TimeSeriesContainer
-        operation_cost::Union{Nothing, TwoPartCost}
         internal::InfrastructureSystemsInternal
     end
 
@@ -22,7 +21,6 @@ Data Structure for the procurement products for system simulations.
 - `requirement::Float64`: the required quantity of the product should be scaled by a TimeSeriesData
 - `ext::Dict{String, Any}`
 - `time_series_container::InfrastructureSystems.TimeSeriesContainer`: internal time_series storage
-- `operation_cost::Union{Nothing, TwoPartCost}`: Cost for providing reserves  [`TwoPartCost`](@ref)
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct VariableReserve{T <: ReserveDirection} <: Reserve{T}
@@ -35,18 +33,16 @@ mutable struct VariableReserve{T <: ReserveDirection} <: Reserve{T}
     ext::Dict{String, Any}
     "internal time_series storage"
     time_series_container::InfrastructureSystems.TimeSeriesContainer
-    "Cost for providing reserves  [`TwoPartCost`](@ref)"
-    operation_cost::Union{Nothing, TwoPartCost}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
-function VariableReserve{T}(name, available, time_frame, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), operation_cost=nothing, ) where T <: ReserveDirection
-    VariableReserve{T}(name, available, time_frame, requirement, ext, time_series_container, operation_cost, InfrastructureSystemsInternal(), )
+function VariableReserve{T}(name, available, time_frame, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), ) where T <: ReserveDirection
+    VariableReserve{T}(name, available, time_frame, requirement, ext, time_series_container, InfrastructureSystemsInternal(), )
 end
 
-function VariableReserve{T}(; name, available, time_frame, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), operation_cost=nothing, internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
-    VariableReserve{T}(name, available, time_frame, requirement, ext, time_series_container, operation_cost, internal, )
+function VariableReserve{T}(; name, available, time_frame, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), ) where T <: ReserveDirection
+    VariableReserve{T}(name, available, time_frame, requirement, ext, time_series_container, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -58,7 +54,6 @@ function VariableReserve{T}(::Nothing) where T <: ReserveDirection
         requirement=0.0,
         ext=Dict{String, Any}(),
         time_series_container=InfrastructureSystems.TimeSeriesContainer(),
-        operation_cost=TwoPartCost(nothing),
     )
 end
 
@@ -74,8 +69,6 @@ get_requirement(value::VariableReserve) = value.requirement
 get_ext(value::VariableReserve) = value.ext
 
 InfrastructureSystems.get_time_series_container(value::VariableReserve) = value.time_series_container
-"""Get [`VariableReserve`](@ref) `operation_cost`."""
-get_operation_cost(value::VariableReserve) = value.operation_cost
 """Get [`VariableReserve`](@ref) `internal`."""
 get_internal(value::VariableReserve) = value.internal
 
@@ -91,6 +84,4 @@ set_requirement!(value::VariableReserve, val) = value.requirement = val
 set_ext!(value::VariableReserve, val) = value.ext = val
 
 InfrastructureSystems.set_time_series_container!(value::VariableReserve, val) = value.time_series_container = val
-"""Set [`VariableReserve`](@ref) `operation_cost`."""
-set_operation_cost!(value::VariableReserve, val) = value.operation_cost = val
 

--- a/src/models/generated/VariableReserveNonSpinning.jl
+++ b/src/models/generated/VariableReserveNonSpinning.jl
@@ -9,7 +9,6 @@ This file is auto-generated. Do not edit.
         requirement::Float64
         ext::Dict{String, Any}
         time_series_container::InfrastructureSystems.TimeSeriesContainer
-        operation_cost::Union{Nothing, TwoPartCost}
         internal::InfrastructureSystemsInternal
     end
 
@@ -22,7 +21,6 @@ Data Structure for the procurement products for system simulations.
 - `requirement::Float64`: the required quantity of the product should be scaled by a TimeSeriesData
 - `ext::Dict{String, Any}`
 - `time_series_container::InfrastructureSystems.TimeSeriesContainer`: internal time_series storage
-- `operation_cost::Union{Nothing, TwoPartCost}`: Cost for providing reserves  [`TwoPartCost`](@ref)
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct VariableReserveNonSpinning <: ReserveNonSpinning
@@ -35,18 +33,16 @@ mutable struct VariableReserveNonSpinning <: ReserveNonSpinning
     ext::Dict{String, Any}
     "internal time_series storage"
     time_series_container::InfrastructureSystems.TimeSeriesContainer
-    "Cost for providing reserves  [`TwoPartCost`](@ref)"
-    operation_cost::Union{Nothing, TwoPartCost}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
-function VariableReserveNonSpinning(name, available, time_frame, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), operation_cost=nothing, )
-    VariableReserveNonSpinning(name, available, time_frame, requirement, ext, time_series_container, operation_cost, InfrastructureSystemsInternal(), )
+function VariableReserveNonSpinning(name, available, time_frame, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), )
+    VariableReserveNonSpinning(name, available, time_frame, requirement, ext, time_series_container, InfrastructureSystemsInternal(), )
 end
 
-function VariableReserveNonSpinning(; name, available, time_frame, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), operation_cost=nothing, internal=InfrastructureSystemsInternal(), )
-    VariableReserveNonSpinning(name, available, time_frame, requirement, ext, time_series_container, operation_cost, internal, )
+function VariableReserveNonSpinning(; name, available, time_frame, requirement, ext=Dict{String, Any}(), time_series_container=InfrastructureSystems.TimeSeriesContainer(), internal=InfrastructureSystemsInternal(), )
+    VariableReserveNonSpinning(name, available, time_frame, requirement, ext, time_series_container, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -58,7 +54,6 @@ function VariableReserveNonSpinning(::Nothing)
         requirement=0.0,
         ext=Dict{String, Any}(),
         time_series_container=InfrastructureSystems.TimeSeriesContainer(),
-        operation_cost=TwoPartCost(nothing),
     )
 end
 
@@ -74,8 +69,6 @@ get_requirement(value::VariableReserveNonSpinning) = value.requirement
 get_ext(value::VariableReserveNonSpinning) = value.ext
 
 InfrastructureSystems.get_time_series_container(value::VariableReserveNonSpinning) = value.time_series_container
-"""Get [`VariableReserveNonSpinning`](@ref) `operation_cost`."""
-get_operation_cost(value::VariableReserveNonSpinning) = value.operation_cost
 """Get [`VariableReserveNonSpinning`](@ref) `internal`."""
 get_internal(value::VariableReserveNonSpinning) = value.internal
 
@@ -91,6 +84,4 @@ set_requirement!(value::VariableReserveNonSpinning, val) = value.requirement = v
 set_ext!(value::VariableReserveNonSpinning, val) = value.ext = val
 
 InfrastructureSystems.set_time_series_container!(value::VariableReserveNonSpinning, val) = value.time_series_container = val
-"""Set [`VariableReserveNonSpinning`](@ref) `operation_cost`."""
-set_operation_cost!(value::VariableReserveNonSpinning, val) = value.operation_cost = val
 


### PR DESCRIPTION
Removes the wrong service costs added mainly [here](https://github.com/NREL-SIIP/PowerSystems.jl/pull/587). Correct approach was implemented in the [cost function update PR](https://github.com/NREL-SIIP/PowerSystems.jl/pull/596).