### PR TITLE
Fix susceptance calculation

### DIFF
--- a/src/models/supplemental_accessors.jl
+++ b/src/models/supplemental_accessors.jl
@@ -15,7 +15,11 @@ _remove_aggregration_topology!(bus::Bus, ::Area) = bus.area = nothing
 Calculate the admittance of AC branches
 """
 get_series_susceptance(b::ACBranch) = -1 / get_x(b)
-get_series_susceptance(b::TapTransformer) = -1 / (get_x(b) * get_tap(b))
+function get_series_susceptance(b::TapTransformer)
+    y = 1 / (get_r(b) + get_x(b) * 1im)
+    y_a = y / (get_tap(b))
+    return imag(y_a)
+end
 function get_series_susceptance(b::PhaseShiftingTransformer)
     y = 1 / (get_r(b) + get_x(b) * 1im)
     y_a = y / (get_tap(b) * exp(get_α(b) * 1im))

--- a/src/models/supplemental_accessors.jl
+++ b/src/models/supplemental_accessors.jl
@@ -17,7 +17,7 @@ Calculate the admittance of AC branches
 get_series_susceptance(b::ACBranch) = imag(1 / (get_r(b) + get_x(b) * 1im))
 function get_series_susceptance(b::TapTransformer)
     y = 1 / (get_r(b) + get_x(b) * 1im)
-    y_a = y / (get_tap(b))
+    y_a = y / get_tap(b)
     return imag(y_a)
 end
 function get_series_susceptance(b::PhaseShiftingTransformer)

--- a/src/models/supplemental_accessors.jl
+++ b/src/models/supplemental_accessors.jl
@@ -14,12 +14,12 @@ _remove_aggregration_topology!(bus::Bus, ::Area) = bus.area = nothing
 """
 Calculate the admittance of AC branches
 """
-get_series_susceptance(b::ACBranch) = 1 / get_x(b)
-get_series_susceptance(b::TapTransformer) = 1 / (get_x(b) * get_tap(b))
+get_series_susceptance(b::ACBranch) = - 1 / get_x(b)
+get_series_susceptance(b::TapTransformer) = - 1 / (get_x(b) * get_tap(b))
 function get_series_susceptance(b::PhaseShiftingTransformer)
     y = 1 / (get_r(b) + get_x(b) * 1im)
-    y_a = y / (get_tap(b) * exp(get_α(b) * 1im * (π / 180)))
-    return 1 / imag(y_a)
+    y_a = y / (get_tap(b) * exp(get_α(b) * 1im))
+    return imag(y_a)
 end
 
 get_series_admittance(b::ACBranch) = 1 / (get_r(b) + get_x(b) * 1im)

--- a/src/models/supplemental_accessors.jl
+++ b/src/models/supplemental_accessors.jl
@@ -14,8 +14,8 @@ _remove_aggregration_topology!(bus::Bus, ::Area) = bus.area = nothing
 """
 Calculate the admittance of AC branches
 """
-get_series_susceptance(b::ACBranch) = - 1 / get_x(b)
-get_series_susceptance(b::TapTransformer) = - 1 / (get_x(b) * get_tap(b))
+get_series_susceptance(b::ACBranch) = -1 / get_x(b)
+get_series_susceptance(b::TapTransformer) = -1 / (get_x(b) * get_tap(b))
 function get_series_susceptance(b::PhaseShiftingTransformer)
     y = 1 / (get_r(b) + get_x(b) * 1im)
     y_a = y / (get_tap(b) * exp(get_α(b) * 1im))

--- a/src/models/supplemental_accessors.jl
+++ b/src/models/supplemental_accessors.jl
@@ -14,7 +14,7 @@ _remove_aggregration_topology!(bus::Bus, ::Area) = bus.area = nothing
 """
 Calculate the admittance of AC branches
 """
-get_series_susceptance(b::ACBranch) = -1 / get_x(b)
+get_series_susceptance(b::ACBranch) = imag(1 / (get_r(b) + get_x(b) * 1im))
 function get_series_susceptance(b::TapTransformer)
     y = 1 / (get_r(b) + get_x(b) * 1im)
     y_a = y / (get_tap(b))


### PR DESCRIPTION
From what we've seen, there are some bugs in these functions:

1. For `PhaseShiftingTransformer`, the function should return `imag(y_a)` instead of `1 /  imag(y_a)`, since `y_a` already is `1 / ...`.
2. There is a conversion to radians when `α` should already be in radians (#649) -- please confirm if this is really the case as I'm not 100% sure.
3. The first two functions are inconsistent with the third. Note that only the third one includes `im`, which means when we calculate `imag(y_a)` we actually get a minus sign in front of the expression due to the `im` in the denominator. A simple fix is to add the minus sign in the other functions for consistency.

A simple example of some of these problems:

```
julia> tr1
FBiqwdLBQB (PhaseShiftingTransformer):
   name: FBiqwdLBQB
   available: false
   active_power_flow: 0.0
   reactive_power_flow: 0.0
   arc: j28BGl4Bn7 -> 63tUEHHV7m: (Arc)
   r: 0.895
   x: 2.972
   primary_shunt: 0.0
   tap: 1.0
   α: 0.0
   rate: 6.69
   ext: Dict{String,Any}()
   forecasts: InfrastructureSystems.Forecasts: 0

julia> tr2 = TapTransformer(
       name=tr1.name, 
       available=tr1.available, 
       active_power_flow=tr1.active_power_flow, 
       reactive_power_flow=tr1.reactive_power_flow,
       arc=tr1.arc, 
       r=tr1.r, 
       x=tr1.x, 
       primary_shunt=tr1.primary_shunt, 
       tap=tr1.tap, 
       rate=tr1.rate
       ) # create identical tap transformer
FBiqwdLBQB (TapTransformer):
   name: FBiqwdLBQB
   available: false
   active_power_flow: 0.0
   reactive_power_flow: 0.0
   arc: j28BGl4Bn7 -> 63tUEHHV7m: (Arc)
   r: 0.895
   x: 2.972
   primary_shunt: 0.0
   tap: 1.0
   rate: 6.69
   services: 0-element Array{Service,1}
   ext: Dict{String,Any}()
   forecasts: InfrastructureSystems.Forecasts: 0

julia> PowerSystems.get_series_susceptance(tr1) # current version - wrong value
-3.2415238896366083

julia> get_series_susceptance(tr1) # fixed version (changed 1/imag to just imag)
-0.3084968780261265

julia> PowerSystems.get_series_susceptance(tr2) # different sign for tap transformer even though it is identical
0.3364737550471063
```

The small difference in absolute value is due to the resistance being considered only for `PhaseShiftingTransformer`.
This is also something to keep in mind - is it really the best approach to consider resistance for `PhaseShiftingTransformer` and disregard it for all other types of branch?