### PR TITLE
add fix to PTDF pst calculation

### DIFF
--- a/src/models/supplemental_accessors.jl
+++ b/src/models/supplemental_accessors.jl
@@ -15,11 +15,17 @@ _remove_aggregration_topology!(bus::Bus, ::Area) = bus.area = nothing
 Calculate the admittance of AC branches
 """
 get_series_susceptance(b::ACBranch) = 1 / get_x(b)
-get_series_susceptance(b::TapTransformer) = 1 / (get_x(b) * get_tap(b))
-function get_series_susceptance(b::PhaseShiftingTransformer)
-    y = 1 / (get_r(b) + get_x(b) * 1im)
-    y_a = y / (get_tap(b) * exp(get_α(b) * 1im * (π / 180)))
-    return 1 / imag(y_a)
+
+
+"""
+Returns the series susceptance of a controllable transformer following the convention
+in power systems to define susceptance as the inverse of the imaginary part of the impedance.
+In the case of phase shifter transformers the angle is ignored.
+"""
+function get_series_susceptance(b::Union{PhaseShiftingTransformer, TapTransformer})
+    y = 1 / get_x(b)
+    y_a = y / (get_tap(b))
+    return y_a
 end
 
 get_series_admittance(b::ACBranch) = 1 / (get_r(b) + get_x(b) * 1im)

--- a/src/models/supplemental_accessors.jl
+++ b/src/models/supplemental_accessors.jl
@@ -16,7 +16,6 @@ Calculate the admittance of AC branches
 """
 get_series_susceptance(b::ACBranch) = 1 / get_x(b)
 
-
 """
 Returns the series susceptance of a controllable transformer following the convention
 in power systems to define susceptance as the inverse of the imaginary part of the impedance.


### PR DESCRIPTION
closes #652 closes #649 @raphaelsaavedra after reviewing several references it seems that this is the best way to go ignoring the angle of the PST since the intended purpose of the PST is to change power flows and if the angle is included the PTDF becomes dependent on the system state. This will be consistent with Matpower and PowerWorld. 