### PR TITLE
Updating Printing 

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -371,6 +371,8 @@ import InfrastructureSystems:
     get_time_series_names,
     get_next_time_series_array!,
     get_next_time,
+    get_units_info,
+    set_units_info!,
     to_json,
     from_json,
     serialize,

--- a/src/base.jl
+++ b/src/base.jl
@@ -278,7 +278,7 @@ end
 Sets the units base for the getter functions on the devices. It modifies the behavior of all getter functions
 """
 function set_units_base_system!(system::System, settings::String)
-    system.units_settings.unit_system = UNIT_SYSTEM_MAPPING[settings]
+    system.units_settings.unit_system = UNIT_SYSTEM_MAPPING[uppercase(settings)]
     @info "Unit System changed to $(UNIT_SYSTEM_MAPPING[settings])"
     return
 end

--- a/src/models/HybridSystem.jl
+++ b/src/models/HybridSystem.jl
@@ -118,7 +118,7 @@ function HybridSystem(::Nothing)
 end
 
 IS.get_name(value::HybridSystem) = value.name
-function set_unit_system!(value::HybridSystem, settings::SystemUnitsSettings)
+function set_units_setting!(value::HybridSystem, settings::SystemUnitsSettings)
     value.internal.units_info = settings
     value.thermal_unit.internal.units_info = settings
     value.electric_load.internal.units_info = settings

--- a/src/models/components.jl
+++ b/src/models/components.jl
@@ -8,9 +8,7 @@ end
 function _get_multiplier(c::T) where {T <: Component}
     setting = get_internal(c).units_info
     if isnothing(setting)
-        # default units settings is NATURAL_UNITS
-        numerator = get_base_power(c)
-        denominator = 1.0
+        return 1.0
     elseif setting.unit_system == IS.DEVICE_BASE
         return 1.0
     elseif setting.unit_system == IS.SYSTEM_BASE

--- a/src/models/components.jl
+++ b/src/models/components.jl
@@ -8,7 +8,9 @@ end
 function _get_multiplier(c::T) where {T <: Component}
     setting = get_internal(c).units_info
     if isnothing(setting)
-        return 1.0
+        # default units settings is NATURAL_UNITS
+        numerator = get_base_power(c)
+        denominator = 1.0
     elseif setting.unit_system == IS.DEVICE_BASE
         return 1.0
     elseif setting.unit_system == IS.SYSTEM_BASE

--- a/src/models/regulation_device.jl
+++ b/src/models/regulation_device.jl
@@ -115,7 +115,7 @@ set_inertia!(value::RegulationDevice, val::Float64) = value.inertia = val
 set_cost!(value::RegulationDevice, val::Float64) = value.cost = val
 IS.set_time_series_container!(value::RegulationDevice, val::IS.TimeSeriesContainer) =
     value.time_series_container = val
-function set_unit_system!(value::RegulationDevice, settings::SystemUnitsSettings)
+function set_units_setting!(value::RegulationDevice, settings::SystemUnitsSettings)
     value.internal.units_info = value.device.internal.units_info = settings
     return
 end

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -45,7 +45,8 @@ function Base.show(io::IO, ist::Component)
     print(io, string(nameof(typeof(ist))), "(")
     is_first = true
     for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
-        if field_type <: IS.TimeSeriesContainer || field_type <: InfrastructureSystemsInternal
+        if field_type <: IS.TimeSeriesContainer ||
+           field_type <: InfrastructureSystemsInternal
             continue
         else
             getter_func = getfield(PowerSystems, Symbol("get_$name"))
@@ -67,7 +68,7 @@ function Base.show(io::IO, ::MIME"text/plain", ist::Component)
         obj = getfield(ist, name)
         if obj isa InfrastructureSystemsInternal
             if isnothing(obj.units_info)
-                print(io, "\n",) 
+                print(io, "\n")
                 @warn("SystemUnitSetting not defined, default to NATURAL_UNITS")
             else
                 print(io, "\n   ")

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -40,3 +40,72 @@ function Base.show(io::IO, ::MIME"text/plain", data::PowerSystemTableData)
         println(io, "$(summary(df))")
     end
 end
+
+function Base.show(io::IO, ist::Component)
+    print(io, string(nameof(typeof(ist))), "(")
+    is_first = true
+    for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
+        if field_type <: IS.TimeSeriesContainer || field_type <: InfrastructureSystemsInternal
+            continue
+        else
+            getter_func = getfield(PowerSystems, Symbol("get_$name"))
+            val = getter_func(ist)
+        end
+        if is_first
+            is_first = false
+        else
+            print(io, ", ")
+        end
+        print(io, val)
+    end
+    print(io, ")")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", ist::Component)
+    print(io, summary(ist), ":")
+    for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
+        obj = getfield(ist, name)
+        if obj isa InfrastructureSystemsInternal
+            print(io, "\n   ")
+            show(io, MIME"text/plain"(), obj.units_info)
+            continue
+        elseif obj isa IS.TimeSeriesContainer || obj isa InfrastructureSystemsType
+            val = summary(getfield(ist, name))
+        elseif obj isa Vector{<:InfrastructureSystemsComponent}
+            val = summary(getfield(ist, name))
+        else
+            getter_func = getfield(PowerSystems, Symbol("get_$name"))
+            val = getter_func(ist)
+        end
+        # Not allowed to print `nothing`
+        if isnothing(val)
+            val = "nothing"
+        end
+        print(io, "\n   ", name, ": ", val)
+    end
+end
+
+
+function Base.show(io::IO, ::MIME"text/html", ist::Component)
+    print(io, summary(ist), ":")
+    for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
+        obj = getfield(ist, name)
+        if obj isa InfrastructureSystemsInternal
+            print(io, "\n   ")
+            show(io, MIME"text/html"(), obj.units_info)
+            continue
+        elseif obj isa IS.TimeSeriesContainer || obj isa InfrastructureSystemsType
+            val = summary(getfield(ist, name))
+        elseif obj isa Vector{<:InfrastructureSystemsComponent}
+            val = summary(getfield(ist, name))
+        else
+            getter_func = getfield(PowerSystems, Symbol("get_$name"))
+            val = getter_func(ist)
+        end
+        # Not allowed to print `nothing`
+        if isnothing(val)
+            val = "nothing"
+        end
+        print(io, "\n   ", name, ": ", val)
+    end
+end

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -64,7 +64,7 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", ist::Component)
     default_units = false
-    if has_units_setting(ist)
+    if !has_units_setting(ist)
         print(io, "\n")
         @warn(
             "SystemUnitSetting not defined, using NATURAL_UNITS for dispalying device specification."
@@ -82,48 +82,6 @@ function Base.show(io::IO, ::MIME"text/plain", ist::Component)
             if (obj isa InfrastructureSystemsInternal) && !default_units
                 print(io, "\n   ")
                 show(io, MIME"text/plain"(), obj.units_info)
-                continue
-            elseif obj isa IS.TimeSeriesContainer ||
-                   obj isa InfrastructureSystemsType ||
-                   obj isa Vector{<:InfrastructureSystemsComponent}
-                val = summary(getfield(ist, name))
-            else
-                getter_func = getfield(PowerSystems, Symbol("get_$name"))
-                val = getter_func(ist)
-            end
-            # Not allowed to print `nothing`
-            if isnothing(val)
-                val = "nothing"
-            end
-            print(io, "\n   ", name, ": ", val)
-        end
-    finally
-        if default_units
-            set_units_setting!(ist, nothing)
-        end
-    end
-end
-
-function Base.show(io::IO, ::MIME"text/html", ist::Component)
-    default_units = false
-    if has_units_setting(ist)
-        print(io, "\n")
-        @warn(
-            "SystemUnitSetting not defined, using NATURAL_UNITS for dispalying device specification."
-        )
-        set_units_setting!(
-            ist,
-            SystemUnitsSettings(100.0, UNIT_SYSTEM_MAPPING["NATURAL_UNITS"]),
-        )
-        default_units = true
-    end
-    try
-        print(io, summary(ist), ":")
-        for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
-            obj = getfield(ist, name)
-            if obj isa InfrastructureSystemsInternal && !default_units
-                print(io, "\n   ")
-                show(io, MIME"text/html"(), obj.units_info)
                 continue
             elseif obj isa IS.TimeSeriesContainer ||
                    obj isa InfrastructureSystemsType ||

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -63,71 +63,77 @@ function Base.show(io::IO, ist::Component)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", ist::Component)
-    defualt_units = false
+    default_units = false
     if isnothing(ist.internal.units_info)
         print(io, "\n")
         @warn("SystemUnitSetting not defined, using NATURAL_UNITS for dispalying device specification.")
         ist.internal.units_info =
             SystemUnitsSettings(100.0, UNIT_SYSTEM_MAPPING["NATURAL_UNITS"])
-        defualt_units = true
+        default_units = true
     end
-    print(io, summary(ist), ":")
-    for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
-        obj = getfield(ist, name)
-        if (obj isa InfrastructureSystemsInternal) && !defualt_units
-            print(io, "\n   ")
-            show(io, MIME"text/plain"(), obj.units_info)
-            continue
-        elseif obj isa IS.TimeSeriesContainer ||
-               obj isa InfrastructureSystemsType ||
-               obj isa Vector{<:InfrastructureSystemsComponent}
-            val = summary(getfield(ist, name))
-        else
-            getter_func = getfield(PowerSystems, Symbol("get_$name"))
-            val = getter_func(ist)
+    try
+        print(io, summary(ist), ":")
+        for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
+            obj = getfield(ist, name)
+            if (obj isa InfrastructureSystemsInternal) && !default_units
+                print(io, "\n   ")
+                show(io, MIME"text/plain"(), obj.units_info)
+                continue
+            elseif obj isa IS.TimeSeriesContainer ||
+                obj isa InfrastructureSystemsType ||
+                obj isa Vector{<:InfrastructureSystemsComponent}
+                val = summary(getfield(ist, name))
+            else
+                getter_func = getfield(PowerSystems, Symbol("get_$name"))
+                val = getter_func(ist)
+            end
+            # Not allowed to print `nothing`
+            if isnothing(val)
+                val = "nothing"
+            end
+            print(io, "\n   ", name, ": ", val)
         end
-        # Not allowed to print `nothing`
-        if isnothing(val)
-            val = "nothing"
+    finally
+        if default_units
+            ist.internal.units_info = nothing
         end
-        print(io, "\n   ", name, ": ", val)
-    end
-    if defualt_units
-        ist.internal.units_info = nothing
     end
 end
 
 function Base.show(io::IO, ::MIME"text/html", ist::Component)
-    defualt_units = false
+    default_units = false
     if isnothing(ist.internal.units_info)
         print(io, "\n")
         @warn("SystemUnitSetting not defined, using NATURAL_UNITS for dispalying device specification.")
         ist.internal.units_info =
             SystemUnitsSettings(100.0, UNIT_SYSTEM_MAPPING["NATURAL_UNITS"])
-        defualt_units = true
+        default_units = true
     end
-    print(io, summary(ist), ":")
-    for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
-        obj = getfield(ist, name)
-        if obj isa InfrastructureSystemsInternal && !defualt_units
-            print(io, "\n   ")
-            show(io, MIME"text/html"(), obj.units_info)
-            continue
-        elseif obj isa IS.TimeSeriesContainer ||
-               obj isa InfrastructureSystemsType ||
-               obj isa Vector{<:InfrastructureSystemsComponent}
-            val = summary(getfield(ist, name))
-        else
-            getter_func = getfield(PowerSystems, Symbol("get_$name"))
-            val = getter_func(ist)
+    try
+        print(io, summary(ist), ":")
+        for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
+            obj = getfield(ist, name)
+            if obj isa InfrastructureSystemsInternal && !default_units
+                print(io, "\n   ")
+                show(io, MIME"text/html"(), obj.units_info)
+                continue
+            elseif obj isa IS.TimeSeriesContainer ||
+                obj isa InfrastructureSystemsType ||
+                obj isa Vector{<:InfrastructureSystemsComponent}
+                val = summary(getfield(ist, name))
+            else
+                getter_func = getfield(PowerSystems, Symbol("get_$name"))
+                val = getter_func(ist)
+            end
+            # Not allowed to print `nothing`
+            if isnothing(val)
+                val = "nothing"
+            end
+            print(io, "\n   ", name, ": ", val)
         end
-        # Not allowed to print `nothing`
-        if isnothing(val)
-            val = "nothing"
+    finally 
+        if default_units
+            ist.internal.units_info = nothing
         end
-        print(io, "\n   ", name, ": ", val)
-    end
-    if defualt_units
-        ist.internal.units_info = nothing
     end
 end

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -66,8 +66,13 @@ function Base.show(io::IO, ::MIME"text/plain", ist::Component)
     for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
         obj = getfield(ist, name)
         if obj isa InfrastructureSystemsInternal
-            print(io, "\n   ")
-            show(io, MIME"text/plain"(), obj.units_info)
+            if isnothing(obj.units_info)
+                print(io, "\n",) 
+                @warn("SystemUnitSetting not defined, default to NATURAL_UNITS")
+            else
+                print(io, "\n   ")
+                show(io, MIME"text/plain"(), obj.units_info)
+            end
             continue
         elseif obj isa IS.TimeSeriesContainer || obj isa InfrastructureSystemsType
             val = summary(getfield(ist, name))
@@ -85,14 +90,17 @@ function Base.show(io::IO, ::MIME"text/plain", ist::Component)
     end
 end
 
-
 function Base.show(io::IO, ::MIME"text/html", ist::Component)
     print(io, summary(ist), ":")
     for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
         obj = getfield(ist, name)
         if obj isa InfrastructureSystemsInternal
-            print(io, "\n   ")
-            show(io, MIME"text/html"(), obj.units_info)
+            if isnothing(obj.units_info)
+                print(io, "\n   SystemUnitSetting not defined, default to NATURAL_UNITS")
+            else
+                print(io, "\n   ")
+                show(io, MIME"text/html"(), obj.units_info)
+            end
             continue
         elseif obj isa IS.TimeSeriesContainer || obj isa InfrastructureSystemsType
             val = summary(getfield(ist, name))

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -64,11 +64,15 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", ist::Component)
     default_units = false
-    if isnothing(ist.internal.units_info)
+    if has_units_setting(ist)
         print(io, "\n")
-        @warn("SystemUnitSetting not defined, using NATURAL_UNITS for dispalying device specification.")
-        ist.internal.units_info =
-            SystemUnitsSettings(100.0, UNIT_SYSTEM_MAPPING["NATURAL_UNITS"])
+        @warn(
+            "SystemUnitSetting not defined, using NATURAL_UNITS for dispalying device specification."
+        )
+        set_units_setting!(
+            ist,
+            SystemUnitsSettings(100.0, UNIT_SYSTEM_MAPPING["NATURAL_UNITS"]),
+        )
         default_units = true
     end
     try
@@ -80,8 +84,8 @@ function Base.show(io::IO, ::MIME"text/plain", ist::Component)
                 show(io, MIME"text/plain"(), obj.units_info)
                 continue
             elseif obj isa IS.TimeSeriesContainer ||
-                obj isa InfrastructureSystemsType ||
-                obj isa Vector{<:InfrastructureSystemsComponent}
+                   obj isa InfrastructureSystemsType ||
+                   obj isa Vector{<:InfrastructureSystemsComponent}
                 val = summary(getfield(ist, name))
             else
                 getter_func = getfield(PowerSystems, Symbol("get_$name"))
@@ -95,18 +99,22 @@ function Base.show(io::IO, ::MIME"text/plain", ist::Component)
         end
     finally
         if default_units
-            ist.internal.units_info = nothing
+            set_units_setting!(ist, nothing)
         end
     end
 end
 
 function Base.show(io::IO, ::MIME"text/html", ist::Component)
     default_units = false
-    if isnothing(ist.internal.units_info)
+    if has_units_setting(ist)
         print(io, "\n")
-        @warn("SystemUnitSetting not defined, using NATURAL_UNITS for dispalying device specification.")
-        ist.internal.units_info =
-            SystemUnitsSettings(100.0, UNIT_SYSTEM_MAPPING["NATURAL_UNITS"])
+        @warn(
+            "SystemUnitSetting not defined, using NATURAL_UNITS for dispalying device specification."
+        )
+        set_units_setting!(
+            ist,
+            SystemUnitsSettings(100.0, UNIT_SYSTEM_MAPPING["NATURAL_UNITS"]),
+        )
         default_units = true
     end
     try
@@ -118,8 +126,8 @@ function Base.show(io::IO, ::MIME"text/html", ist::Component)
                 show(io, MIME"text/html"(), obj.units_info)
                 continue
             elseif obj isa IS.TimeSeriesContainer ||
-                obj isa InfrastructureSystemsType ||
-                obj isa Vector{<:InfrastructureSystemsComponent}
+                   obj isa InfrastructureSystemsType ||
+                   obj isa Vector{<:InfrastructureSystemsComponent}
                 val = summary(getfield(ist, name))
             else
                 getter_func = getfield(PowerSystems, Symbol("get_$name"))
@@ -131,9 +139,9 @@ function Base.show(io::IO, ::MIME"text/html", ist::Component)
             end
             print(io, "\n   ", name, ": ", val)
         end
-    finally 
+    finally
         if default_units
-            ist.internal.units_info = nothing
+            set_units_setting!(ist, nothing)
         end
     end
 end

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -67,7 +67,7 @@ function Base.show(io::IO, ::MIME"text/plain", ist::Component)
     if !has_units_setting(ist)
         print(io, "\n")
         @warn(
-            "SystemUnitSetting not defined, using NATURAL_UNITS for dispalying device specification."
+            "SystemUnitSetting not defined, using NATURAL_UNITS for displaying device specification."
         )
         set_units_setting!(
             ist,


### PR DESCRIPTION
- Adding show method for PowerSystems Components that uses the getter function instead of get field
- Other change here is in `_get_multiplier` when unit settings is nothing  was to return 1.0 i.e DEVICE_BASE, now this is changed to NATURAL_UNITS.
- Changes to Test to reflect the changes in `_get_multiplier`


Requires IS#187 to be merged and tagged for Documentation to pass