### PR TITLE
Replace all enums with new scoped_enum macro

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -4,80 +4,70 @@ const From_To_Float = NamedTuple{(:from, :to), Tuple{Float64, Float64}}
 const FromTo_ToFrom_Float = NamedTuple{(:from_to, :to_from), Tuple{Float64, Float64}}
 
 "From http://www.pserc.cornell.edu/matpower/MATPOWER-manual.pdf Table B-4"
-IS.@scoped_enum GeneratorCostModel begin
-    PIECEWISE_LINEAR = 1
-    POLYNOMIAL = 2
-end
 
-IS.@scoped_enum AngleUnit begin
-    DEGREES
-    RADIANS
-end
+IS.@scoped_enum(GeneratorCostModels, PIECEWISE_LINEAR = 1, POLYNOMIAL = 2,)
 
-IS.@scoped_enum BusType begin
-    ISOLATED
-    PQ
-    PV
-    REF
-    SLACK
-end
+IS.@scoped_enum(AngleUnits, DEGREES = 1, RADIANS = 2,)
 
-IS.@scoped_enum LoadModel begin
-    ConstantImpedance # Z
-    ConstantCurrent   # I
-    ConstantPower     # P
-end
+IS.@scoped_enum(BusTypes, ISOLATED = 1, PQ = 2, PV = 3, REF = 4, SLACK = 5,)
+
+IS.@scoped_enum(
+    LoadModels,
+    ConstantImpedance = 1, # Z
+    ConstantCurrent = 2,   # I
+    ConstantPower = 3,     # P
+)
 
 "From https://www.eia.gov/survey/form/eia_923/instructions.pdf"
-IS.@scoped_enum PrimeMover begin
-    BA # Energy Storage, Battery
-    BT # Turbines Used in a Binary Cycle (including those used for geothermal applications)
-    CA # Combined-Cycle – Steam Part
-    CC # Combined-Cycle - Aggregated Plant *augmentation of EIA
-    CE # Energy Storage, Compressed Air
-    CP # Energy Storage, Concentrated Solar Power
-    CS # Combined-Cycle Single-Shaft Combustion turbine and steam turbine share a single generator
-    CT # Combined-Cycle Combustion Turbine Part
-    ES # Energy Storage, Other (Specify on Schedule 9, Comments)
-    FC # Fuel Cell
-    FW # Energy Storage, Flywheel
-    GT # Combustion (Gas) Turbine (including jet engine design)
-    HA # Hydrokinetic, Axial Flow Turbine
-    HB # Hydrokinetic, Wave Buoy
-    HK # Hydrokinetic, Other
-    HY # Hydraulic Turbine (including turbines associated with delivery of water by pipeline)
-    IC # Internal Combustion (diesel, piston, reciprocating) Engine
-    PS # Energy Storage, Reversible Hydraulic Turbine (Pumped Storage)
-    OT # Other – Specify on SCHEDULE 9.
-    ST # Steam Turbine (including nuclear, geothermal and solar steam; does not include combined-cycle turbine)
-    PVe # Photovoltaic *renaming from EIA PV to PVe to avoid conflict with BusType.PV
-    WT # Wind Turbine, Onshore
-    WS # Wind Turbine, Offshore
-end
+
+IS.@scoped_enum(
+    PrimeMovers,
+    BA = 1,  # Energy Storage, Battery
+    BT = 2,  # Turbines Used in a Binary Cycle (including those used for geothermal applications)
+    CA = 3,  # Combined-Cycle – Steam Part
+    CC = 4,  # Combined-Cycle - Aggregated Plant *augmentation of EIA
+    CE = 5,  # Energy Storage, Compressed Air
+    CP = 6,  # Energy Storage, Concentrated Solar Power
+    CS = 7,  # Combined-Cycle Single-Shaft Combustion turbine and steam turbine share a single generator
+    CT = 8,  # Combined-Cycle Combustion Turbine Part
+    ES = 9,  # Energy Storage, Other (Specify on Schedule 9, Comments)
+    FC = 10,  # Fuel Cell
+    FW = 11,  # Energy Storage, Flywheel
+    GT = 12,  # Combustion (Gas) Turbine (including jet engine design)
+    HA = 13,  # Hydrokinetic, Axial Flow Turbine
+    HB = 14,  # Hydrokinetic, Wave Buoy
+    HK = 15,  # Hydrokinetic, Other
+    HY = 16,  # Hydraulic Turbine (including turbines associated with delivery of water by pipeline)
+    IC = 17,  # Internal Combustion (diesel, piston, reciprocating) Engine
+    PS = 18,  # Energy Storage, Reversible Hydraulic Turbine (Pumped Storage)
+    OT = 19,  # Other – Specify on SCHEDULE 9.
+    ST = 20,  # Steam Turbine (including nuclear, geothermal and solar steam; does not include combined-cycle turbine)
+    PVe = 21,  # Photovoltaic *renaming from EIA PV to PVe to avoid conflict with BusType.PV
+    WT = 22,  # Wind Turbine, Onshore
+    WS = 23,  # Wind Turbine, Offshore
+)
 
 "AER Aggregated Fuel Code From https://www.eia.gov/survey/form/eia_923/instructions.pdf"
-IS.@scoped_enum ThermalFuel begin
-    COAL # COL    # Anthracite Coal and Bituminous Coal
-    WASTE_COAL # WOC    # Waste/Other Coal (includes anthracite culm, gob, fine coal, lignite waste, waste coal)
-    DISTILLATE_FUEL_OIL # DFO # Distillate Fuel Oil (Diesel, No. 1, No. 2, and No. 4
-    WASTE_OIL # WOO    # Waste Oil Kerosene and JetFuel Butane, Propane,
-    PETROLEUM_COKE # PC  # Petroleum Coke
-    RESIDUAL_FUEL_OIL    # RFO # Residual Fuel Oil (No. 5, No. 6 Fuel Oils, and Bunker Oil)
-    NATURAL_GAS # NG    # Natural Gas
-    OTHER_GAS # OOG    # Other Gas and blast furnace gas
-    NUCLEAR # NUC # Nuclear Fission (Uranium, Plutonium, Thorium)
-    AG_BIPRODUCT # ORW    # Agricultural Crop Byproducts/Straw/Energy Crops
-    MUNICIPAL_WASTE # MLG    # Municipal Solid Waste – Biogenic component
-    WOOD_WASTE # WWW     # Wood Waste Liquids excluding Black Liquor (BLQ) (Includes red liquor, sludge wood, spent sulfite liquor, and other wood-based liquids)
-    GEOTHERMAL # GEO     # Geothermal
-    OTHER # OTH     # Other
-end
 
-IS.@scoped_enum StateType begin
-    Differential
-    Algebraic
-    Hybrid
-end
+IS.@scoped_enum(
+    ThermalFuels,
+    COAL = 1,  # COL    # Anthracite Coal and Bituminous Coal
+    WASTE_COAL = 2,  # WOC    # Waste/Other Coal (includes anthracite culm, gob, fine coal, lignite waste, waste coal)
+    DISTILLATE_FUEL_OIL = 3,  # DFO # Distillate Fuel Oil (Diesel, No. 1, No. 2, and No. 4
+    WASTE_OIL = 4,  # WOO    # Waste Oil Kerosene and JetFuel Butane, Propane,
+    PETROLEUM_COKE = 5,  # PC  # Petroleum Coke
+    RESIDUAL_FUEL_OIL = 6,     # RFO # Residual Fuel Oil (No. 5, No. 6 Fuel Oils, and Bunker Oil)
+    NATURAL_GAS = 7,  # NG    # Natural Gas
+    OTHER_GAS = 8,  # OOG    # Other Gas and blast furnace gas
+    NUCLEAR = 9,  # NUC # Nuclear Fission (Uranium, Plutonium, Thorium)
+    AG_BIPRODUCT = 10,  # ORW    # Agricultural Crop Byproducts/Straw/Energy Crops
+    MUNICIPAL_WASTE = 11,  # MLG    # Municipal Solid Waste – Biogenic component
+    WOOD_WASTE = 12,  # WWW     # Wood Waste Liquids excluding Black Liquor (BLQ) (Includes red liquor, sludge wood, spent sulfite liquor, and other wood-based liquids)
+    GEOTHERMAL = 13,  # GEO     # Geothermal
+    OTHER = 14,  # OTH     # Other
+)
+
+IS.@scoped_enum(StateTypes, Differential = 1, Algebraic = 2, Hybrid = 3,)
 
 PS_MAX_LOG = parse(Int, get(ENV, "PS_MAX_LOG", "50"))
 DEFAULT_BASE_MVA = 100.0

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -257,7 +257,7 @@
           "name": "bustype",
           "comment": "bus type",
           "null_value": "nothing",
-          "data_type": "Union{Nothing, BusTypes.BusType}"
+          "data_type": "Union{Nothing, BusTypes}"
         },
         {
           "name": "angle",
@@ -1126,7 +1126,7 @@
         {
           "name": "model",
           "null_value": "LoadModels.ConstantPower",
-          "data_type": "LoadModels.LoadModel"
+          "data_type": "LoadModels"
         },
         {
           "name": "active_power",
@@ -1287,7 +1287,7 @@
         {
           "name": "model",
           "null_value": "nothing",
-          "data_type": "Union{Nothing, LoadModels.LoadModel}"
+          "data_type": "Union{Nothing, LoadModels}"
         },
         {
           "name": "active_power",
@@ -1412,7 +1412,7 @@
           "name": "prime_mover",
           "comment": "Prime mover technology according to EIA 923",
           "null_value": "PrimeMovers.HY",
-          "data_type": "PrimeMovers.PrimeMover"
+          "data_type": "PrimeMovers"
         },
         {
           "name": "active_power_limits",
@@ -1612,7 +1612,7 @@
           "name": "prime_mover",
           "comment": "Prime mover technology according to EIA 923",
           "null_value": "PrimeMovers.HY",
-          "data_type": "PrimeMovers.PrimeMover"
+          "data_type": "PrimeMovers"
         },
         {
           "name": "active_power_limits",
@@ -1770,7 +1770,7 @@
           "name": "prime_mover",
           "comment": "Prime mover technology according to EIA 923",
           "null_value": "PrimeMovers.HY",
-          "data_type": "PrimeMovers.PrimeMover"
+          "data_type": "PrimeMovers"
         },
         {
           "name": "active_power_limits",
@@ -2033,7 +2033,7 @@
           "name": "prime_mover",
           "comment": "Prime mover technology according to EIA 923",
           "null_value": "PrimeMovers.OT",
-          "data_type": "PrimeMovers.PrimeMover"
+          "data_type": "PrimeMovers"
         },
         {
           "name": "reactive_power_limits",
@@ -2155,7 +2155,7 @@
           "name": "prime_mover",
           "comment": "Prime mover technology according to EIA 923",
           "null_value": "PrimeMovers.OT",
-          "data_type": "PrimeMovers.PrimeMover"
+          "data_type": "PrimeMovers"
         },
         {
           "name": "power_factor",
@@ -2331,14 +2331,14 @@
           "name": "prime_mover",
           "comment": "Prime mover technology according to EIA 923",
           "null_value": "PrimeMovers.OT",
-          "data_type": "PrimeMovers.PrimeMover",
+          "data_type": "PrimeMovers",
           "default": "PrimeMovers.OT"
         },
         {
           "name": "fuel",
           "comment": "Prime mover fuel according to EIA 923",
           "null_value": "ThermalFuels.OTHER",
-          "data_type": "ThermalFuels.ThermalFuel",
+          "data_type": "ThermalFuels",
           "default": "ThermalFuels.OTHER"
         },
         {
@@ -2443,13 +2443,13 @@
           "name": "prime_mover",
           "comment": "Prime mover technology according to EIA 923",
           "null_value": "PrimeMovers.OT",
-          "data_type": "PrimeMovers.PrimeMover"
+          "data_type": "PrimeMovers"
         },
         {
           "name": "fuel",
           "comment": "Prime mover fuel according to EIA 923",
           "null_value": "ThermalFuels.OTHER",
-          "data_type": "ThermalFuels.ThermalFuel"
+          "data_type": "ThermalFuels"
         },
         {
           "name": "active_power_limits",
@@ -2604,7 +2604,7 @@
           "name": "prime_mover",
           "comment": "Prime mover technology according to EIA 923",
           "null_value": "PrimeMovers.BA",
-          "data_type": "PrimeMovers.PrimeMover"
+          "data_type": "PrimeMovers"
         },
         {
           "name": "initial_energy",
@@ -3231,8 +3231,8 @@
         {
           "name": "states_types",
           "comment": "Fixed AVR has no states",
-          "internal_default": "Vector{StateTypes.StateType}()",
-          "data_type": "Vector{StateTypes.StateType}"
+          "internal_default": "Vector{StateTypes}()",
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -3293,7 +3293,7 @@
           "name": "states_types",
           "comment": "Simple AVR has 1 differential states",
           "internal_default": "[StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -3478,7 +3478,7 @@
           "name": "states_types",
           "comment": "ESDC1A has 5 differential states",
           "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -3664,7 +3664,7 @@
           "name": "states_types",
           "comment": "ESDC2A has 5 differential states",
           "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -3827,7 +3827,7 @@
           "name": "states_types",
           "comment": "IEEET1 I has 4 differential states",
           "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -3974,7 +3974,7 @@
           "name": "states_types",
           "comment": "AVR Type I has 4 differential states",
           "internal_default": "[StateTypes.Differential, StateTypes.Differential, StateTypes.Differential, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -4121,7 +4121,7 @@
           "name": "states_types",
           "comment": "AVR Type II has 4 differential states",
           "internal_default": "[StateTypes.Differential, StateTypes.Differential, StateTypes.Differential, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -4244,7 +4244,7 @@
           "name": "states_types",
           "comment": "SCRX has 2 differential states",
           "internal_default": "[StateTypes.Differential, StateTypes.Hybrid]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -4446,7 +4446,7 @@
           "name": "states_types",
           "comment": "ESAC1A has 5 states",
           "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -4647,7 +4647,7 @@
           "name": "states_types",
           "comment": "EXAC1A has 5 states",
           "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -4842,7 +4842,7 @@
           "name": "states_types",
           "comment": "EXAC1 has 5 states",
           "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -5088,7 +5088,7 @@
           "name": "states_types",
           "comment": "EXAC2 has 5 states",
           "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -5333,7 +5333,7 @@
           "name": "states_types",
           "comment": "ESAC6A has 5 states",
           "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Hybrid]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -5554,7 +5554,7 @@
           "name": "states_types",
           "comment": "ST1A has 5 states",
           "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -5794,7 +5794,7 @@
           "name": "states_types",
           "comment": "EXPIC has 6 states",
           "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Hybrid]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -6007,7 +6007,7 @@
           "name": "states_types",
           "comment": "ST4B has 4 states",
           "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -7780,7 +7780,7 @@
           "name": "states_types",
           "comment": "IEEEST has 7 differential states",
           "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -8230,7 +8230,7 @@
           "name": "states_types",
           "comment": "GAST has 3 differential states",
           "internal_default": "[StateTypes.Differential, StateTypes.Differential, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -8618,7 +8618,7 @@
           "name": "states_types",
           "comment": "GGOV1 has 10 differential states",
           "internal_default": "[StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Differential, StateTypes.Hybrid]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -8763,7 +8763,7 @@
           "name": "states_types",
           "comment": "TGOV1 has 2 differential states",
           "internal_default": "[StateTypes.Differential, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -8930,7 +8930,7 @@
           "name": "states_types",
           "comment": "HYGOV has 4 differential states",
           "internal_default": "[StateTypes.Differential, StateTypes.Differential, StateTypes.Differential, StateTypes.Differential]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",
@@ -9185,7 +9185,7 @@
           "name": "states_types",
           "comment": "IEEEG1 has 6 differential states",
           "internal_default": "[StateTypes.Differential, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid, StateTypes.Hybrid]",
-          "data_type": "Vector{StateTypes.StateType}"
+          "data_type": "Vector{StateTypes}"
         },
         {
           "name": "internal",

--- a/src/models/components.jl
+++ b/src/models/components.jl
@@ -9,12 +9,12 @@ function _get_multiplier(c::T) where {T <: Component}
     setting = get_internal(c).units_info
     if isnothing(setting)
         return 1.0
-    elseif setting.unit_system == IS.DEVICE_BASE
+    elseif setting.unit_system == IS.UnitSystem.DEVICE_BASE
         return 1.0
-    elseif setting.unit_system == IS.SYSTEM_BASE
+    elseif setting.unit_system == IS.UnitSystem.SYSTEM_BASE
         numerator = get_base_power(c)
         denominator = setting.base_value
-    elseif setting.unit_system == IS.NATURAL_UNITS
+    elseif setting.unit_system == IS.UnitSystem.NATURAL_UNITS
         numerator = get_base_power(c)
         denominator = 1.0
     else

--- a/src/models/generated/AVRFixed.jl
+++ b/src/models/generated/AVRFixed.jl
@@ -8,7 +8,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -20,7 +20,7 @@ Parameters of a AVR that returns a fixed voltage to the rotor winding
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: Fixed AVR has no states
 - `n_states::Int`: Fixed AVR has no states
-- `states_types::Vector{StateTypes.StateType}`: Fixed AVR has no states
+- `states_types::Vector{StateTypes}`: Fixed AVR has no states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct AVRFixed <: AVR
@@ -34,16 +34,16 @@ mutable struct AVRFixed <: AVR
     "Fixed AVR has no states"
     n_states::Int
     "Fixed AVR has no states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end
 
 function AVRFixed(Vf, V_ref=1.0, ext=Dict{String, Any}(), )
-    AVRFixed(Vf, V_ref, ext, Vector{Symbol}(), 0, Vector{StateTypes.StateType}(), InfrastructureSystemsInternal(), )
+    AVRFixed(Vf, V_ref, ext, Vector{Symbol}(), 0, Vector{StateTypes}(), InfrastructureSystemsInternal(), )
 end
 
-function AVRFixed(; Vf, V_ref=1.0, ext=Dict{String, Any}(), states=Vector{Symbol}(), n_states=0, states_types=Vector{StateTypes.StateType}(), internal=InfrastructureSystemsInternal(), )
+function AVRFixed(; Vf, V_ref=1.0, ext=Dict{String, Any}(), states=Vector{Symbol}(), n_states=0, states_types=Vector{StateTypes}(), internal=InfrastructureSystemsInternal(), )
     AVRFixed(Vf, V_ref, ext, states, n_states, states_types, internal, )
 end
 

--- a/src/models/generated/AVRSimple.jl
+++ b/src/models/generated/AVRSimple.jl
@@ -8,7 +8,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -22,7 +22,7 @@ i.e. an integrator controller on EMF
 - `states::Vector{Symbol}`: The states are:
 	Vf: field voltage
 - `n_states::Int`: Fixed AVR has 1 states
-- `states_types::Vector{StateTypes.StateType}`: Simple AVR has 1 differential states
+- `states_types::Vector{StateTypes}`: Simple AVR has 1 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct AVRSimple <: AVR
@@ -37,7 +37,7 @@ mutable struct AVRSimple <: AVR
     "Fixed AVR has 1 states"
     n_states::Int
     "Simple AVR has 1 differential states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/AVRTypeI.jl
+++ b/src/models/generated/AVRTypeI.jl
@@ -17,7 +17,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -42,7 +42,7 @@ Parameters of an Automatic Voltage Regulator Type I - Resembles IEEE Type DC1
 	Vr2: Stabilizing Feedback State,
 	Vm: Measured voltage
 - `n_states::Int`: The AVR Type I has 4 states
-- `states_types::Vector{StateTypes.StateType}`: AVR Type I has 4 differential states
+- `states_types::Vector{StateTypes}`: AVR Type I has 4 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct AVRTypeI <: AVR
@@ -78,7 +78,7 @@ mutable struct AVRTypeI <: AVR
     "The AVR Type I has 4 states"
     n_states::Int
     "AVR Type I has 4 differential states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/AVRTypeII.jl
+++ b/src/models/generated/AVRTypeII.jl
@@ -17,7 +17,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -42,7 +42,7 @@ Parameters of an Automatic Voltage Regulator Type II -  Typical static exciter m
 	Vr2: Second lead-lag state,
 	Vm: Measured voltage
 - `n_states::Int`: AVR Type II has 4 states
-- `states_types::Vector{StateTypes.StateType}`: AVR Type II has 4 differential states
+- `states_types::Vector{StateTypes}`: AVR Type II has 4 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct AVRTypeII <: AVR
@@ -78,7 +78,7 @@ mutable struct AVRTypeII <: AVR
     "AVR Type II has 4 states"
     n_states::Int
     "AVR Type II has 4 differential states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/Bus.jl
+++ b/src/models/generated/Bus.jl
@@ -5,7 +5,7 @@ This file is auto-generated. Do not edit.
     mutable struct Bus <: Topology
         number::Int
         name::String
-        bustype::Union{Nothing, BusTypes.BusType}
+        bustype::Union{Nothing, BusTypes}
         angle::Union{Nothing, Float64}
         magnitude::Union{Nothing, Float64}
         voltage_limits::Union{Nothing, Min_Max}
@@ -21,7 +21,7 @@ A power-system bus.
 # Arguments
 - `number::Int`: number associated with the bus
 - `name::String`: the name of the bus
-- `bustype::Union{Nothing, BusTypes.BusType}`: bus type
+- `bustype::Union{Nothing, BusTypes}`: bus type
 - `angle::Union{Nothing, Float64}`: angle of the bus in radians, validation range: `(-1.571, 1.571)`, action if invalid: `error`
 - `magnitude::Union{Nothing, Float64}`: voltage as a multiple of basevoltage, validation range: `voltage_limits`, action if invalid: `warn`
 - `voltage_limits::Union{Nothing, Min_Max}`: limits on the voltage variation as multiples of basevoltage
@@ -37,7 +37,7 @@ mutable struct Bus <: Topology
     "the name of the bus"
     name::String
     "bus type"
-    bustype::Union{Nothing, BusTypes.BusType}
+    bustype::Union{Nothing, BusTypes}
     "angle of the bus in radians"
     angle::Union{Nothing, Float64}
     "voltage as a multiple of basevoltage"

--- a/src/models/generated/ESAC1A.jl
+++ b/src/models/generated/ESAC1A.jl
@@ -23,7 +23,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -57,7 +57,7 @@ Parameters of IEEE Std 421.5 Type AC1A Excitacion System. This model corresponds
 	Ve: Integrator output state,
 	Vr3: Feedback output state
 - `n_states::Int`: ESAC1A has 5 states
-- `states_types::Vector{StateTypes.StateType}`: ESAC1A has 5 states
+- `states_types::Vector{StateTypes}`: ESAC1A has 5 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct ESAC1A <: AVR
@@ -106,7 +106,7 @@ mutable struct ESAC1A <: AVR
     "ESAC1A has 5 states"
     n_states::Int
     "ESAC1A has 5 states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/ESAC6A.jl
+++ b/src/models/generated/ESAC6A.jl
@@ -27,7 +27,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -64,7 +64,7 @@ Parameters of IEEE Std 421.5 Type AC6A Excitacion System. ESAC6A in PSSE and PSL
 	Ve: Integrator output state,
 	Vr3: Feedback output state
 - `n_states::Int`: ESAC6A has 5 states
-- `states_types::Vector{StateTypes.StateType}`: ESAC6A has 5 states
+- `states_types::Vector{StateTypes}`: ESAC6A has 5 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct ESAC6A <: AVR
@@ -121,7 +121,7 @@ mutable struct ESAC6A <: AVR
     "ESAC6A has 5 states"
     n_states::Int
     "ESAC6A has 5 states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/ESDC1A.jl
+++ b/src/models/generated/ESDC1A.jl
@@ -21,7 +21,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -52,7 +52,7 @@ Parameters of IEEE Std 421.5 Type DC1A Excitacion System. This model corresponds
 	Vf: Exciter Output, 
 	Vr3: Rate feedback integrator
 - `n_states::Int`: The ESDC1A has 5 states
-- `states_types::Vector{StateTypes.StateType}`: ESDC1A has 5 differential states
+- `states_types::Vector{StateTypes}`: ESDC1A has 5 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct ESDC1A <: AVR
@@ -97,7 +97,7 @@ mutable struct ESDC1A <: AVR
     "The ESDC1A has 5 states"
     n_states::Int
     "ESDC1A has 5 differential states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/ESDC2A.jl
+++ b/src/models/generated/ESDC2A.jl
@@ -21,7 +21,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -52,7 +52,7 @@ Parameters of IEEE Std 421.5 Type DC2A Excitacion System. This model corresponds
 	Vf: Exciter Output, 
 	Vr3: Rate feedback integrator
 - `n_states::Int`: The ESDC2A has 5 states
-- `states_types::Vector{StateTypes.StateType}`: ESDC2A has 5 differential states
+- `states_types::Vector{StateTypes}`: ESDC2A has 5 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct ESDC2A <: AVR
@@ -97,7 +97,7 @@ mutable struct ESDC2A <: AVR
     "The ESDC2A has 5 states"
     n_states::Int
     "ESDC2A has 5 differential states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/ESST1A.jl
+++ b/src/models/generated/ESST1A.jl
@@ -24,7 +24,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -58,7 +58,7 @@ Parameters of IEEE Std 421.5 Type ST1A Excitacion System. ESST1A in PSSE and PSL
 	Va: Regulator output state,
 	Vr3: Feedback output state
 - `n_states::Int`: ST1A has 5 states
-- `states_types::Vector{StateTypes.StateType}`: ST1A has 5 states
+- `states_types::Vector{StateTypes}`: ST1A has 5 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct ESST1A <: AVR
@@ -109,7 +109,7 @@ mutable struct ESST1A <: AVR
     "ST1A has 5 states"
     n_states::Int
     "ST1A has 5 states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/ESST4B.jl
+++ b/src/models/generated/ESST4B.jl
@@ -23,7 +23,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -56,7 +56,7 @@ Parameters of IEEE Std 421.5 Type ST4B Excitacion System. ESST4B in PSSE and PSL
 	Vr2: Regulator Output,
 	Vm: Output integrator
 - `n_states::Int`: ST4B has 4 states
-- `states_types::Vector{StateTypes.StateType}`: ST4B has 4 states
+- `states_types::Vector{StateTypes}`: ST4B has 4 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct ESST4B <: AVR
@@ -105,7 +105,7 @@ mutable struct ESST4B <: AVR
     "ST4B has 4 states"
     n_states::Int
     "ST4B has 4 states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/EXAC1.jl
+++ b/src/models/generated/EXAC1.jl
@@ -22,7 +22,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -55,7 +55,7 @@ Parameters of IEEE Std 421.5 Type AC1A.  EXAC1 in PSSE and PSLF
 	Ve: Integrator output state,
 	Vr3: Feedback output state
 - `n_states::Int`: EXAC1 has 5 states
-- `states_types::Vector{StateTypes.StateType}`: EXAC1 has 5 states
+- `states_types::Vector{StateTypes}`: EXAC1 has 5 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct EXAC1 <: AVR
@@ -102,7 +102,7 @@ mutable struct EXAC1 <: AVR
     "EXAC1 has 5 states"
     n_states::Int
     "EXAC1 has 5 states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/EXAC1A.jl
+++ b/src/models/generated/EXAC1A.jl
@@ -23,7 +23,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -57,7 +57,7 @@ Parameters of IEEE Std 421.5 Type AC1A Excitacion System. EXAC1A in PSSE and PSL
 	Ve: Integrator output state,
 	Vr3: Feedback output state
 - `n_states::Int`: EXAC1A has 5 states
-- `states_types::Vector{StateTypes.StateType}`: EXAC1A has 5 states
+- `states_types::Vector{StateTypes}`: EXAC1A has 5 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct EXAC1A <: AVR
@@ -106,7 +106,7 @@ mutable struct EXAC1A <: AVR
     "EXAC1A has 5 states"
     n_states::Int
     "EXAC1A has 5 states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/EXAC2.jl
+++ b/src/models/generated/EXAC2.jl
@@ -27,7 +27,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -65,7 +65,7 @@ Parameters of IEEE Std 421.5 Type AC2A Excitacion System. The alternator main ex
 	Ve: Integrator output state,
 	Vr3: Feedback output state
 - `n_states::Int`: EXAC2 has 5 states
-- `states_types::Vector{StateTypes.StateType}`: EXAC2 has 5 states
+- `states_types::Vector{StateTypes}`: EXAC2 has 5 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct EXAC2 <: AVR
@@ -122,7 +122,7 @@ mutable struct EXAC2 <: AVR
     "EXAC2 has 5 states"
     n_states::Int
     "EXAC2 has 5 states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/EXPIC1.jl
+++ b/src/models/generated/EXPIC1.jl
@@ -27,7 +27,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -65,7 +65,7 @@ Generic Proportional/Integral Excitation System
 	Vr3: First feedback integrator,
 	Vr4: second feedback integrator
 - `n_states::Int`: EXPIC1 has 6 states
-- `states_types::Vector{StateTypes.StateType}`: EXPIC has 6 states
+- `states_types::Vector{StateTypes}`: EXPIC has 6 states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct EXPIC1 <: AVR
@@ -124,7 +124,7 @@ mutable struct EXPIC1 <: AVR
     "EXPIC1 has 6 states"
     n_states::Int
     "EXPIC has 6 states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/GasTG.jl
+++ b/src/models/generated/GasTG.jl
@@ -15,7 +15,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -37,7 +37,7 @@ Parameters of Gas Turbine-Governor. GAST in PSSE and GAST_PTI in PowerWorld.
 	x_g2: Fuel flow,
 	x_g3: Exhaust temperature load
 - `n_states::Int`: GasTG has 3 states
-- `states_types::Vector{StateTypes.StateType}`: GAST has 3 differential states
+- `states_types::Vector{StateTypes}`: GAST has 3 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct GasTG <: TurbineGov
@@ -68,7 +68,7 @@ mutable struct GasTG <: TurbineGov
     "GasTG has 3 states"
     n_states::Int
     "GAST has 3 differential states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/GeneralGovModel.jl
+++ b/src/models/generated/GeneralGovModel.jl
@@ -39,7 +39,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -92,7 +92,7 @@ GE General Governor/Turbine Model. The GeneralGovModel (GGOV1) model is a genera
 	x_g8: Acceleration Control, 
 	x_g9 Temperature Detection Lead - Lag:
 - `n_states::Int`: GeneralGovModel has 10 states
-- `states_types::Vector{StateTypes.StateType}`: GGOV1 has 10 differential states
+- `states_types::Vector{StateTypes}`: GGOV1 has 10 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct GeneralGovModel <: TurbineGov
@@ -178,7 +178,7 @@ mutable struct GeneralGovModel <: TurbineGov
     "GeneralGovModel has 10 states"
     n_states::Int
     "GGOV1 has 10 differential states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/GenericBattery.jl
+++ b/src/models/generated/GenericBattery.jl
@@ -6,7 +6,7 @@ This file is auto-generated. Do not edit.
         name::String
         available::Bool
         bus::Bus
-        prime_mover::PrimeMovers.PrimeMover
+        prime_mover::PrimeMovers
         initial_energy::Float64
         state_of_charge_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
         rating::Float64
@@ -30,7 +30,7 @@ Data structure for a generic battery
 - `name::String`
 - `available::Bool`
 - `bus::Bus`
-- `prime_mover::PrimeMovers.PrimeMover`: Prime mover technology according to EIA 923
+- `prime_mover::PrimeMovers`: Prime mover technology according to EIA 923
 - `initial_energy::Float64`: State of Charge of the Battery p.u.-hr, validation range: `(0, nothing)`, action if invalid: `error`
 - `state_of_charge_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}`: Maximum and Minimum storage capacity in p.u.-hr, validation range: `(0, nothing)`, action if invalid: `error`
 - `rating::Float64`
@@ -52,7 +52,7 @@ mutable struct GenericBattery <: Storage
     available::Bool
     bus::Bus
     "Prime mover technology according to EIA 923"
-    prime_mover::PrimeMovers.PrimeMover
+    prime_mover::PrimeMovers
     "State of Charge of the Battery p.u.-hr"
     initial_energy::Float64
     "Maximum and Minimum storage capacity in p.u.-hr"

--- a/src/models/generated/HydroDispatch.jl
+++ b/src/models/generated/HydroDispatch.jl
@@ -9,7 +9,7 @@ This file is auto-generated. Do not edit.
         active_power::Float64
         reactive_power::Float64
         rating::Float64
-        prime_mover::PrimeMovers.PrimeMover
+        prime_mover::PrimeMovers
         active_power_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
         reactive_power_limits::Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}
         ramp_limits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
@@ -32,7 +32,7 @@ This file is auto-generated. Do not edit.
 - `active_power::Float64`
 - `reactive_power::Float64`, validation range: `reactive_power_limits`, action if invalid: `warn`
 - `rating::Float64`: Thermal limited MVA Power Output of the unit. <= Capacity, validation range: `(0, nothing)`, action if invalid: `error`
-- `prime_mover::PrimeMovers.PrimeMover`: Prime mover technology according to EIA 923
+- `prime_mover::PrimeMovers`: Prime mover technology according to EIA 923
 - `active_power_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}`, validation range: `(0, nothing)`, action if invalid: `warn`
 - `reactive_power_limits::Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}`, action if invalid: `warn`
 - `ramp_limits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}`: ramp up and ramp down limits in MW (in component base per unit) per minute, validation range: `(0, nothing)`, action if invalid: `error`
@@ -54,7 +54,7 @@ mutable struct HydroDispatch <: HydroGen
     "Thermal limited MVA Power Output of the unit. <= Capacity"
     rating::Float64
     "Prime mover technology according to EIA 923"
-    prime_mover::PrimeMovers.PrimeMover
+    prime_mover::PrimeMovers
     active_power_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
     reactive_power_limits::Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}
     "ramp up and ramp down limits in MW (in component base per unit) per minute"

--- a/src/models/generated/HydroEnergyReservoir.jl
+++ b/src/models/generated/HydroEnergyReservoir.jl
@@ -9,7 +9,7 @@ This file is auto-generated. Do not edit.
         active_power::Float64
         reactive_power::Float64
         rating::Float64
-        prime_mover::PrimeMovers.PrimeMover
+        prime_mover::PrimeMovers
         active_power_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
         reactive_power_limits::Union{Nothing, Min_Max}
         ramp_limits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
@@ -38,7 +38,7 @@ This file is auto-generated. Do not edit.
 - `active_power::Float64`
 - `reactive_power::Float64`, validation range: `reactive_power_limits`, action if invalid: `warn`
 - `rating::Float64`: Thermal limited MVA Power Output of the unit. <= Capacity, validation range: `(0, nothing)`, action if invalid: `error`
-- `prime_mover::PrimeMovers.PrimeMover`: Prime mover technology according to EIA 923
+- `prime_mover::PrimeMovers`: Prime mover technology according to EIA 923
 - `active_power_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}`
 - `reactive_power_limits::Union{Nothing, Min_Max}`, action if invalid: `warn`
 - `ramp_limits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}`: ramp up and ramp down limits in MW (in component base per unit) per minute, validation range: `(0, nothing)`, action if invalid: `error`
@@ -66,7 +66,7 @@ mutable struct HydroEnergyReservoir <: HydroGen
     "Thermal limited MVA Power Output of the unit. <= Capacity"
     rating::Float64
     "Prime mover technology according to EIA 923"
-    prime_mover::PrimeMovers.PrimeMover
+    prime_mover::PrimeMovers
     active_power_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
     reactive_power_limits::Union{Nothing, Min_Max}
     "ramp up and ramp down limits in MW (in component base per unit) per minute"

--- a/src/models/generated/HydroPumpedStorage.jl
+++ b/src/models/generated/HydroPumpedStorage.jl
@@ -10,7 +10,7 @@ This file is auto-generated. Do not edit.
         reactive_power::Float64
         rating::Float64
         base_power::Float64
-        prime_mover::PrimeMovers.PrimeMover
+        prime_mover::PrimeMovers
         active_power_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
         reactive_power_limits::Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}
         ramp_limits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
@@ -46,7 +46,7 @@ This file is auto-generated. Do not edit.
 - `reactive_power::Float64`
 - `rating::Float64`: Thermal limited MVA Power Output of the unit. <= Capacity, validation range: `(0, nothing)`, action if invalid: `error`
 - `base_power::Float64`: Base power of the unit in MVA, validation range: `(0, nothing)`, action if invalid: `warn`
-- `prime_mover::PrimeMovers.PrimeMover`: Prime mover technology according to EIA 923
+- `prime_mover::PrimeMovers`: Prime mover technology according to EIA 923
 - `active_power_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}`, validation range: `(0, nothing)`, action if invalid: `warn`
 - `reactive_power_limits::Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}`, action if invalid: `warn`
 - `ramp_limits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}`: ramp up and ramp down limits in MW (in component base per unit) per minute, validation range: `(0, nothing)`, action if invalid: `error`
@@ -82,7 +82,7 @@ mutable struct HydroPumpedStorage <: HydroGen
     "Base power of the unit in MVA"
     base_power::Float64
     "Prime mover technology according to EIA 923"
-    prime_mover::PrimeMovers.PrimeMover
+    prime_mover::PrimeMovers
     active_power_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
     reactive_power_limits::Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}
     "ramp up and ramp down limits in MW (in component base per unit) per minute"

--- a/src/models/generated/HydroTurbineGov.jl
+++ b/src/models/generated/HydroTurbineGov.jl
@@ -18,7 +18,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -44,7 +44,7 @@ Hydro Turbine-Governor.
 	x_g3: gate opening, 
 	x_g4: turbine flow
 - `n_states::Int`: HYGOV has 4 states
-- `states_types::Vector{StateTypes.StateType}`: HYGOV has 4 differential states
+- `states_types::Vector{StateTypes}`: HYGOV has 4 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct HydroTurbineGov <: TurbineGov
@@ -82,7 +82,7 @@ mutable struct HydroTurbineGov <: TurbineGov
     "HYGOV has 4 states"
     n_states::Int
     "HYGOV has 4 differential states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/IEEEST.jl
+++ b/src/models/generated/IEEEST.jl
@@ -24,7 +24,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -59,7 +59,7 @@ IEEE Stabilizing Model PSS.
 	x_p6: T3/T4 lead-lag integrator, 
 	:x_p7 last integer,
 - `n_states::Int`: IEEEST has 7 states
-- `states_types::Vector{StateTypes.StateType}`: IEEEST has 7 differential states
+- `states_types::Vector{StateTypes}`: IEEEST has 7 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct IEEEST <: PSS
@@ -112,7 +112,7 @@ mutable struct IEEEST <: PSS
     "IEEEST has 7 states"
     n_states::Int
     "IEEEST has 7 differential states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/IEEET1.jl
+++ b/src/models/generated/IEEET1.jl
@@ -19,7 +19,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -46,7 +46,7 @@ This file is auto-generated. Do not edit.
 	Vf: Exciter Output, 
 	Vr3: Rate feedback integrator
 - `n_states::Int`: The IEEET1 has 4 states
-- `states_types::Vector{StateTypes.StateType}`: IEEET1 I has 4 differential states
+- `states_types::Vector{StateTypes}`: IEEET1 I has 4 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct IEEET1 <: AVR
@@ -86,7 +86,7 @@ mutable struct IEEET1 <: AVR
     "The IEEET1 has 4 states"
     n_states::Int
     "IEEET1 I has 4 differential states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/IEEETurbineGov1.jl
+++ b/src/models/generated/IEEETurbineGov1.jl
@@ -26,7 +26,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -62,7 +62,7 @@ IEEE Type 1 Speed-Governing Model
 	x_g5: Third Turbine Integrator, 
 	x_g6: Fourth Turbine Integrator, 
 - `n_states::Int`: IEEEG1 has 6 states
-- `states_types::Vector{StateTypes.StateType}`: IEEEG1 has 6 differential states
+- `states_types::Vector{StateTypes}`: IEEEG1 has 6 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct IEEETurbineGov1 <: TurbineGov
@@ -118,7 +118,7 @@ mutable struct IEEETurbineGov1 <: TurbineGov
     "IEEEG1 has 6 states"
     n_states::Int
     "IEEEG1 has 6 differential states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/InterruptibleLoad.jl
+++ b/src/models/generated/InterruptibleLoad.jl
@@ -6,7 +6,7 @@ This file is auto-generated. Do not edit.
         name::String
         available::Bool
         bus::Bus
-        model::LoadModels.LoadModel
+        model::LoadModels
         active_power::Float64
         reactive_power::Float64
         max_active_power::Float64
@@ -26,7 +26,7 @@ This file is auto-generated. Do not edit.
 - `name::String`
 - `available::Bool`
 - `bus::Bus`
-- `model::LoadModels.LoadModel`
+- `model::LoadModels`
 - `active_power::Float64`
 - `reactive_power::Float64`
 - `max_active_power::Float64`
@@ -43,7 +43,7 @@ mutable struct InterruptibleLoad <: ControllableLoad
     name::String
     available::Bool
     bus::Bus
-    model::LoadModels.LoadModel
+    model::LoadModels
     active_power::Float64
     reactive_power::Float64
     max_active_power::Float64

--- a/src/models/generated/PowerLoad.jl
+++ b/src/models/generated/PowerLoad.jl
@@ -6,7 +6,7 @@ This file is auto-generated. Do not edit.
         name::String
         available::Bool
         bus::Bus
-        model::Union{Nothing, LoadModels.LoadModel}
+        model::Union{Nothing, LoadModels}
         active_power::Float64
         reactive_power::Float64
         base_power::Float64
@@ -25,7 +25,7 @@ Data structure for a static power load.
 - `name::String`
 - `available::Bool`
 - `bus::Bus`
-- `model::Union{Nothing, LoadModels.LoadModel}`
+- `model::Union{Nothing, LoadModels}`
 - `active_power::Float64`
 - `reactive_power::Float64`
 - `base_power::Float64`: Base power of the unit in MVA, validation range: `(0, nothing)`, action if invalid: `warn`
@@ -41,7 +41,7 @@ mutable struct PowerLoad <: StaticLoad
     name::String
     available::Bool
     bus::Bus
-    model::Union{Nothing, LoadModels.LoadModel}
+    model::Union{Nothing, LoadModels}
     active_power::Float64
     reactive_power::Float64
     "Base power of the unit in MVA"

--- a/src/models/generated/RenewableDispatch.jl
+++ b/src/models/generated/RenewableDispatch.jl
@@ -9,7 +9,7 @@ This file is auto-generated. Do not edit.
         active_power::Float64
         reactive_power::Float64
         rating::Float64
-        prime_mover::PrimeMovers.PrimeMover
+        prime_mover::PrimeMovers
         reactive_power_limits::Union{Nothing, Min_Max}
         power_factor::Float64
         operation_cost::TwoPartCost
@@ -30,7 +30,7 @@ This file is auto-generated. Do not edit.
 - `active_power::Float64`
 - `reactive_power::Float64`
 - `rating::Float64`: Thermal limited MVA Power Output of the unit. <= Capacity, validation range: `(0, nothing)`, action if invalid: `error`
-- `prime_mover::PrimeMovers.PrimeMover`: Prime mover technology according to EIA 923
+- `prime_mover::PrimeMovers`: Prime mover technology according to EIA 923
 - `reactive_power_limits::Union{Nothing, Min_Max}`
 - `power_factor::Float64`, validation range: `(0, 1)`, action if invalid: `error`
 - `operation_cost::TwoPartCost`: Operation Cost of Generation [`TwoPartCost`](@ref)
@@ -50,7 +50,7 @@ mutable struct RenewableDispatch <: RenewableGen
     "Thermal limited MVA Power Output of the unit. <= Capacity"
     rating::Float64
     "Prime mover technology according to EIA 923"
-    prime_mover::PrimeMovers.PrimeMover
+    prime_mover::PrimeMovers
     reactive_power_limits::Union{Nothing, Min_Max}
     power_factor::Float64
     "Operation Cost of Generation [`TwoPartCost`](@ref)"

--- a/src/models/generated/RenewableFix.jl
+++ b/src/models/generated/RenewableFix.jl
@@ -9,7 +9,7 @@ This file is auto-generated. Do not edit.
         active_power::Float64
         reactive_power::Float64
         rating::Float64
-        prime_mover::PrimeMovers.PrimeMover
+        prime_mover::PrimeMovers
         power_factor::Float64
         base_power::Float64
         services::Vector{Service}
@@ -28,7 +28,7 @@ Data Structure for fixed renewable generation technologies.
 - `active_power::Float64`
 - `reactive_power::Float64`
 - `rating::Float64`: Thermal limited MVA Power Output of the unit. <= Capacity, validation range: `(0, nothing)`, action if invalid: `error`
-- `prime_mover::PrimeMovers.PrimeMover`: Prime mover technology according to EIA 923
+- `prime_mover::PrimeMovers`: Prime mover technology according to EIA 923
 - `power_factor::Float64`, validation range: `(0, 1)`, action if invalid: `error`
 - `base_power::Float64`: Base power of the unit in MVA, validation range: `(0, nothing)`, action if invalid: `warn`
 - `services::Vector{Service}`: Services that this device contributes to
@@ -46,7 +46,7 @@ mutable struct RenewableFix <: RenewableGen
     "Thermal limited MVA Power Output of the unit. <= Capacity"
     rating::Float64
     "Prime mover technology according to EIA 923"
-    prime_mover::PrimeMovers.PrimeMover
+    prime_mover::PrimeMovers
     power_factor::Float64
     "Base power of the unit in MVA"
     base_power::Float64

--- a/src/models/generated/SCRX.jl
+++ b/src/models/generated/SCRX.jl
@@ -14,7 +14,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -34,7 +34,7 @@ This exciter is based on an IEEE type SCRX solid state exciter.  The output fiel
 	Vr1: First integrator,
 	Vr2: Second integrator
 - `n_states::Int`: SCRX has 2 states
-- `states_types::Vector{StateTypes.StateType}`: SCRX has 2 differential states
+- `states_types::Vector{StateTypes}`: SCRX has 2 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct SCRX <: AVR
@@ -62,7 +62,7 @@ mutable struct SCRX <: AVR
     "SCRX has 2 states"
     n_states::Int
     "SCRX has 2 differential states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/SteamTurbineGov1.jl
+++ b/src/models/generated/SteamTurbineGov1.jl
@@ -16,7 +16,7 @@ This file is auto-generated. Do not edit.
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
-        states_types::Vector{StateTypes.StateType}
+        states_types::Vector{StateTypes}
         internal::InfrastructureSystemsInternal
     end
 
@@ -38,7 +38,7 @@ Steam Turbine-Governor. This model considers both TGOV1 or TGOV1DU in PSS/E.
 	x_g1: Valve Opening,
 	x_g2: Lead-lag state
 - `n_states::Int`: TGOV1 has 2 states
-- `states_types::Vector{StateTypes.StateType}`: TGOV1 has 2 differential states
+- `states_types::Vector{StateTypes}`: TGOV1 has 2 differential states
 - `internal::InfrastructureSystemsInternal`: power system internal reference, do not modify
 """
 mutable struct SteamTurbineGov1 <: TurbineGov
@@ -70,7 +70,7 @@ mutable struct SteamTurbineGov1 <: TurbineGov
     "TGOV1 has 2 states"
     n_states::Int
     "TGOV1 has 2 differential states"
-    states_types::Vector{StateTypes.StateType}
+    states_types::Vector{StateTypes}
     "power system internal reference, do not modify"
     internal::InfrastructureSystemsInternal
 end

--- a/src/models/generated/ThermalMultiStart.jl
+++ b/src/models/generated/ThermalMultiStart.jl
@@ -10,8 +10,8 @@ This file is auto-generated. Do not edit.
         active_power::Float64
         reactive_power::Float64
         rating::Float64
-        prime_mover::PrimeMovers.PrimeMover
-        fuel::ThermalFuels.ThermalFuel
+        prime_mover::PrimeMovers
+        fuel::ThermalFuels
         active_power_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
         reactive_power_limits::Union{Nothing, Min_Max}
         ramp_limits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
@@ -40,8 +40,8 @@ Data Structure for thermal generation technologies.
 - `active_power::Float64`, validation range: `active_power_limits`, action if invalid: `warn`
 - `reactive_power::Float64`, validation range: `reactive_power_limits`, action if invalid: `warn`
 - `rating::Float64`: Thermal limited MVA Power Output of the unit. <= Capacity, validation range: `(0, nothing)`, action if invalid: `error`
-- `prime_mover::PrimeMovers.PrimeMover`: Prime mover technology according to EIA 923
-- `fuel::ThermalFuels.ThermalFuel`: Prime mover fuel according to EIA 923
+- `prime_mover::PrimeMovers`: Prime mover technology according to EIA 923
+- `fuel::ThermalFuels`: Prime mover fuel according to EIA 923
 - `active_power_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}`
 - `reactive_power_limits::Union{Nothing, Min_Max}`
 - `ramp_limits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}`, validation range: `(0, nothing)`, action if invalid: `error`
@@ -69,9 +69,9 @@ mutable struct ThermalMultiStart <: ThermalGen
     "Thermal limited MVA Power Output of the unit. <= Capacity"
     rating::Float64
     "Prime mover technology according to EIA 923"
-    prime_mover::PrimeMovers.PrimeMover
+    prime_mover::PrimeMovers
     "Prime mover fuel according to EIA 923"
-    fuel::ThermalFuels.ThermalFuel
+    fuel::ThermalFuels
     active_power_limits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
     reactive_power_limits::Union{Nothing, Min_Max}
     ramp_limits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}

--- a/src/models/generated/ThermalStandard.jl
+++ b/src/models/generated/ThermalStandard.jl
@@ -16,8 +16,8 @@ This file is auto-generated. Do not edit.
         operation_cost::OperationalCost
         base_power::Float64
         time_limits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
-        prime_mover::PrimeMovers.PrimeMover
-        fuel::ThermalFuels.ThermalFuel
+        prime_mover::PrimeMovers
+        fuel::ThermalFuels
         services::Vector{Service}
         time_at_status::Float64
         dynamic_injector::Union{Nothing, DynamicInjection}
@@ -42,8 +42,8 @@ Data Structure for thermal generation technologies.
 - `operation_cost::OperationalCost`
 - `base_power::Float64`: Base power of the unit in MVA, validation range: `(0, nothing)`, action if invalid: `warn`
 - `time_limits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}`: Minimum up and Minimum down time limits in hours, validation range: `(0, nothing)`, action if invalid: `error`
-- `prime_mover::PrimeMovers.PrimeMover`: Prime mover technology according to EIA 923
-- `fuel::ThermalFuels.ThermalFuel`: Prime mover fuel according to EIA 923
+- `prime_mover::PrimeMovers`: Prime mover technology according to EIA 923
+- `fuel::ThermalFuels`: Prime mover fuel according to EIA 923
 - `services::Vector{Service}`: Services that this device contributes to
 - `time_at_status::Float64`
 - `dynamic_injector::Union{Nothing, DynamicInjection}`: corresponding dynamic injection device
@@ -70,9 +70,9 @@ mutable struct ThermalStandard <: ThermalGen
     "Minimum up and Minimum down time limits in hours"
     time_limits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
     "Prime mover technology according to EIA 923"
-    prime_mover::PrimeMovers.PrimeMover
+    prime_mover::PrimeMovers
     "Prime mover fuel according to EIA 923"
-    fuel::ThermalFuels.ThermalFuel
+    fuel::ThermalFuels
     "Services that this device contributes to"
     services::Vector{Service}
     time_at_status::Float64

--- a/src/models/supplemental_constructors.jl
+++ b/src/models/supplemental_constructors.jl
@@ -14,7 +14,7 @@ function PowerLoadPF(
     name::String,
     available::Bool,
     bus::Bus,
-    model::Union{Nothing, LoadModels.LoadModel},
+    model::Union{Nothing, LoadModels},
     active_power::Float64,
     max_active_power::Float64,
     power_factor::Float64,
@@ -82,7 +82,7 @@ function Bus(
     return Bus(
         number,
         name,
-        get_enum_value(BusTypes.BusType, bustype),
+        get_enum_value(BusTypes, bustype),
         angle,
         voltage,
         voltage_limits,

--- a/src/parsers/common.jl
+++ b/src/parsers/common.jl
@@ -4,7 +4,7 @@ const GENERATOR_MAPPING_FILE =
 const PSSE_DYR_MAPPING_FILE =
     joinpath(dirname(pathof(PowerSystems)), "parsers", "psse_dynamic_mapping.yaml")
 
-const STRING2FUEL = Dict((string(e) => e) for e in instances(ThermalFuels.ThermalFuel))
+const STRING2FUEL = Dict((string(x) => x) for x in instances(ThermalFuels))
 merge!(
     STRING2FUEL,
     Dict(
@@ -17,7 +17,7 @@ merge!(
     ),
 )
 
-const STRING2PRIMEMOVER = Dict((string(e) => e) for e in instances(PrimeMovers.PrimeMover))
+const STRING2PRIMEMOVER = Dict((string(x) => x) for x in instances(PrimeMovers))
 merge!(
     STRING2PRIMEMOVER,
     Dict(
@@ -145,18 +145,18 @@ function convert_units!(
     return value
 end
 
-function parse_enum_mapping(::Type{ThermalFuels.ThermalFuel}, fuel::AbstractString)
+function parse_enum_mapping(::Type{ThermalFuels}, fuel::AbstractString)
     return STRING2FUEL[uppercase(fuel)]
 end
 
-function parse_enum_mapping(::Type{ThermalFuels.ThermalFuel}, fuel::Symbol)
-    return parse_enum_mapping(ThermalFuels.ThermalFuel, string(fuel))
+function parse_enum_mapping(::Type{ThermalFuels}, fuel::Symbol)
+    return parse_enum_mapping(ThermalFuels, string(fuel))
 end
 
-function parse_enum_mapping(::Type{PrimeMovers.PrimeMover}, prime_mover::AbstractString)
+function parse_enum_mapping(::Type{PrimeMovers}, prime_mover::AbstractString)
     return STRING2PRIMEMOVER[uppercase(prime_mover)]
 end
 
-function parse_enum_mapping(::Type{PrimeMovers.PrimeMover}, prime_mover::Symbol)
-    return parse_enum_mapping(PrimeMovers.PrimeMover, string(prime_mover))
+function parse_enum_mapping(::Type{PrimeMovers}, prime_mover::Symbol)
+    return parse_enum_mapping(PrimeMovers, string(prime_mover))
 end

--- a/src/parsers/enums.jl
+++ b/src/parsers/enums.jl
@@ -1,24 +1,25 @@
 
-@enum InputCategory begin
-    BRANCH
-    BUS
-    DC_BRANCH
-    GENERATOR
-    LOAD
-    RESERVE
-    SIMULATION_OBJECTS
-    STORAGE
-end
+IS.@scoped_enum(
+    InputCategory,
+    BRANCH = 1,
+    BUS = 2,
+    DC_BRANCH = 3,
+    GENERATOR = 4,
+    LOAD = 5,
+    RESERVE = 6,
+    SIMULATION_OBJECTS = 7,
+    STORAGE = 8,
+)
 
 const ENUMS = (
-    AngleUnits.AngleUnit,
-    BusTypes.BusType,
-    GeneratorCostModels.GeneratorCostModel,
+    AngleUnits,
+    BusTypes,
+    GeneratorCostModels,
     InputCategory,
-    LoadModels.LoadModel,
-    PrimeMovers.PrimeMover,
-    StateTypes.StateType,
-    ThermalFuels.ThermalFuel,
+    LoadModels,
+    PrimeMovers,
+    StateTypes,
+    ThermalFuels,
     UnitSystem,
 )
 
@@ -45,16 +46,11 @@ function get_enum_value(enum, value::String)
     return ENUM_MAPPINGS[enum][val]
 end
 
-Base.convert(::Type{AngleUnits.AngleUnit}, val::String) =
-    get_enum_value(AngleUnits.AngleUnit, val)
-Base.convert(::Type{BusTypes.BusType}, val::String) = get_enum_value(BusTypes.BusType, val)
-Base.convert(::Type{GeneratorCostModels.GeneratorCostModel}, val::String) =
-    get_enum_value(GeneratorCostModels.GeneratorCostModel, val)
-Base.convert(::Type{LoadModels.LoadModel}, val::String) =
-    get_enum_value(LoadModels.LoadModel, val)
-Base.convert(::Type{PrimeMovers.PrimeMover}, val::String) =
-    get_enum_value(PrimeMovers.PrimeMover, val)
-Base.convert(::Type{StateTypes.StateType}, val::String) =
-    get_enum_value(StateTypes.StateType, val)
-Base.convert(::Type{ThermalFuels.ThermalFuel}, val::String) =
-    get_enum_value(ThermalFuels.ThermalFuel, val)
+Base.convert(::Type{AngleUnits}, val::String) = get_enum_value(AngleUnits, val)
+Base.convert(::Type{BusTypes}, val::String) = get_enum_value(BusTypes, val)
+Base.convert(::Type{GeneratorCostModels}, val::String) =
+    get_enum_value(GeneratorCostModels, val)
+Base.convert(::Type{LoadModels}, val::String) = get_enum_value(LoadModels, val)
+Base.convert(::Type{PrimeMovers}, val::String) = get_enum_value(PrimeMovers, val)
+Base.convert(::Type{StateTypes}, val::String) = get_enum_value(StateTypes, val)
+Base.convert(::Type{ThermalFuels}, val::String) = get_enum_value(ThermalFuels, val)

--- a/src/parsers/pm_io/common.jl
+++ b/src/parsers/pm_io/common.jl
@@ -84,8 +84,8 @@ function correct_network_data!(data::Dict{String, <:Any})
 end
 
 UNIT_SYSTEM_MAPPING = Dict(
-    "SYSTEM_BASE" => IS.SYSTEM_BASE,
-    "DEVICE_BASE" => IS.DEVICE_BASE,
-    "NATURAL_UNITS" => IS.NATURAL_UNITS,
+    "SYSTEM_BASE" => IS.UnitSystem.SYSTEM_BASE,
+    "DEVICE_BASE" => IS.UnitSystem.DEVICE_BASE,
+    "NATURAL_UNITS" => IS.UnitSystem.NATURAL_UNITS,
     "NA" => nothing,
 )

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -123,12 +123,13 @@ function make_bus(bus_name, bus_number, d, bus_types, area)
 end
 
 # "From http://www.pserc.cornell.edu/matpower/MATPOWER-manual.pdf Table B-1"
-IS.@scoped_enum MatpowerBusType begin
-    MATPOWER_PQ = 1
-    MATPOWER_PV = 2
-    MATPOWER_REF = 3
-    MATPOWER_ISOLATED = 4
-end
+IS.@scoped_enum(
+    MatpowerBusTypes,
+    MATPOWER_PQ = 1,
+    MATPOWER_PV = 2,
+    MATPOWER_REF = 3,
+    MATPOWER_ISOLATED = 4,
+)
 
 const _BUS_TYPE_MAP = Dict(
     MatpowerBusTypes.MATPOWER_ISOLATED => BusTypes.ISOLATED,
@@ -137,7 +138,7 @@ const _BUS_TYPE_MAP = Dict(
     MatpowerBusTypes.MATPOWER_REF => BusTypes.REF,
 )
 
-function Base.convert(::Type{BusTypes.BusType}, x::MatpowerBusTypes.MatpowerBusType)
+function Base.convert(::Type{BusTypes}, x::MatpowerBusTypes)
     return _BUS_TYPE_MAP[x]
 end
 
@@ -159,7 +160,7 @@ function read_bus!(sys::System, data; kwargs...)
     @info "Reading bus data"
     bus_number_to_bus = Dict{Int, Bus}()
 
-    bus_types = instances(MatpowerBusTypes.MatpowerBusType)
+    bus_types = instances(MatpowerBusTypes)
     bus_data = sort!(collect(data["bus"]), by = x -> parse(Int, x[1]))
 
     if isempty(bus_data)
@@ -279,7 +280,7 @@ function make_hydro_gen(gen_name, d, bus, sys_mbase)
         active_power = d["pg"] * base_conversion,
         reactive_power = d["qg"] * base_conversion,
         rating = calculate_rating(d["pmax"], d["qmax"]) * base_conversion,
-        prime_mover = parse_enum_mapping(PrimeMovers.PrimeMover, d["type"]),
+        prime_mover = parse_enum_mapping(PrimeMovers, d["type"]),
         active_power_limits = (
             min = d["pmin"] * base_conversion,
             max = d["pmax"] * base_conversion,
@@ -306,7 +307,7 @@ function make_renewable_dispatch(gen_name, d, bus, sys_mbase)
         active_power = d["pg"] * base_conversion,
         reactive_power = d["qg"] * base_conversion,
         rating = float(d["pmax"]) * base_conversion,
-        prime_mover = parse_enum_mapping(PrimeMovers.PrimeMover, d["type"]),
+        prime_mover = parse_enum_mapping(PrimeMovers, d["type"]),
         reactive_power_limits = (
             min = d["qmin"] * base_conversion,
             max = d["qmax"] * base_conversion,
@@ -328,7 +329,7 @@ function make_renewable_fix(gen_name, d, bus, sys_mbase)
         active_power = d["pg"] * base_conversion,
         reactive_power = d["qg"] * base_conversion,
         rating = float(d["pmax"]) * base_conversion,
-        prime_mover = parse_enum_mapping(PrimeMovers.PrimeMover, d["type"]),
+        prime_mover = parse_enum_mapping(PrimeMovers, d["type"]),
         power_factor = 1.0,
         base_power = d["mbase"],
     )
@@ -363,7 +364,7 @@ The polynomial term follows the convention that for an n-degree polynomial, at l
 """
 function make_thermal_gen(gen_name::AbstractString, d::Dict, bus::Bus, sys_mbase::Number)
     if haskey(d, "model")
-        model = GeneratorCostModels.GeneratorCostModel(d["model"])
+        model = GeneratorCostModels(d["model"])
         if model == GeneratorCostModels.PIECEWISE_LINEAR
             cost_component = d["cost"]
             power_p = [i for (ix, i) in enumerate(cost_component) if isodd(ix)]
@@ -431,8 +432,8 @@ function make_thermal_gen(gen_name::AbstractString, d::Dict, bus::Bus, sys_mbase
         active_power = d["pg"] * base_conversion,
         reactive_power = d["qg"] * base_conversion,
         rating = sqrt(d["pmax"]^2 + d["qmax"]^2) * base_conversion,
-        prime_mover = parse_enum_mapping(PrimeMovers.PrimeMover, d["type"]),
-        fuel = parse_enum_mapping(ThermalFuels.ThermalFuel, d["fuel"]),
+        prime_mover = parse_enum_mapping(PrimeMovers, d["type"]),
+        fuel = parse_enum_mapping(ThermalFuels, d["fuel"]),
         active_power_limits = (
             min = d["pmin"] * base_conversion,
             max = d["pmax"] * base_conversion,


### PR DESCRIPTION
This does two things:
1. Adopt the new `scoped_enum` from InfrastructureSystems (https://github.com/NREL-SIIP/InfrastructureSystems.jl/pull/192/files)
2. Replace any regular enums with scoped_enum

I tested deserialization of a System created with the old version and it worked.

I do have a concern that this will cause an API breakage for users. It depends on whether they actually use something like `BusTypes.BusType`, which is hopefully unlikely.