### PR TITLE
Simplify system checks

### DIFF
--- a/docs/src/model_developer_guide/adding_custom_types.md
+++ b/docs/src/model_developer_guide/adding_custom_types.md
@@ -64,9 +64,9 @@ and `throw_if_not_attached(component, system)`.
 You can implement three methods to perform custom validation or correction for your type.
 PowerSystems calls all of these functions in `add_component!`.
 
-- `sanitize_compoment!(component::Component, sys::System)`
-- `validate_compoment(component::Component)`
-- `validate_component_with_system(component::Component, sys::System)`
+- `sanitize_component!(component::Component, sys::System)`: intended to make standard data corrections (e.g. voltage angle in degrees -> radians)
+- `validate_component(component::Component)`: intended to check component field values for internal consistency
+- `validate_component_with_system(component::Component, sys::System)`: intended to check component field values for consistency with system
 
 ### Struct Requirements for Serialization of custom components
 

--- a/docs/src/model_developer_guide/adding_custom_types.md
+++ b/docs/src/model_developer_guide/adding_custom_types.md
@@ -59,6 +59,15 @@ supertype of your type.
 Note that you can call the helper functions `is_attached(component, system)`
 and `throw_if_not_attached(component, system)`.
 
+### Custom Validation
+
+You can implement three methods to perform custom validation or correction for your type.
+PowerSystems calls all of these functions in `add_component!`.
+
+- `correct_compoment!(component::Component, sys::System)`
+- `validate_compoment(component::Component)`
+- `validate_component_with_system(component::Component, sys::System)`
+
 ### Struct Requirements for Serialization of custom components
 
 One key feature of `PowerSystems.jl` is the serialization capabilities. Supporting

--- a/docs/src/model_developer_guide/adding_custom_types.md
+++ b/docs/src/model_developer_guide/adding_custom_types.md
@@ -64,7 +64,7 @@ and `throw_if_not_attached(component, system)`.
 You can implement three methods to perform custom validation or correction for your type.
 PowerSystems calls all of these functions in `add_component!`.
 
-- `correct_compoment!(component::Component, sys::System)`
+- `sanitize_compoment!(component::Component, sys::System)`
 - `validate_compoment(component::Component)`
 - `validate_component_with_system(component::Component, sys::System)`
 

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -308,11 +308,17 @@ export get_reserve_limit_dn
 export get_participation_factor
 export get_cost
 export get_units_base
+export get_runchecks
+export set_runchecks!
+export check!
+export check_component
+export check_components
 
 export configure_logging
 export open_file_logger
 export MultiLogger
 export LogEventTracker
+export UnitSystem
 
 #################################################################################
 # Imports

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -261,7 +261,7 @@ export set_service_bid!
 export iterate_windows
 export get_window
 export transform_single_time_series!
-export correct_component!
+export sanitize_component!
 export validate_component
 export validate_component_with_system
 

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -261,6 +261,9 @@ export set_service_bid!
 export iterate_windows
 export get_window
 export transform_single_time_series!
+export correct_component!
+export validate_component
+export validate_component_with_system
 
 #export make_time_series
 export get_bus_numbers
@@ -310,7 +313,7 @@ export get_cost
 export get_units_base
 export get_runchecks
 export set_runchecks!
-export check!
+export check
 export check_component
 export check_components
 
@@ -390,6 +393,7 @@ import InfrastructureSystems:
     UnitSystem,
     SystemUnitsSettings,
     open_file_logger,
+    validate_struct,
     MultiLogger,
     LogEventTracker
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -1109,7 +1109,7 @@ end
 """
 Sanitize component values.
 """
-correct_component!(component::Component, sys::System) = true
+sanitize_component!(component::Component, sys::System) = true
 
 """
 Validate the component fields using only those fields. Refer to
@@ -1713,7 +1713,7 @@ function _validate_or_skip!(sys, component, skip_validation)
     end
 
     if !skip_validation
-        correct_component!(component, sys)
+        sanitize_component!(component, sys)
         if !validate_component_with_system(component, sys)
             throw(IS.InvalidValue("Invalid value for $component"))
         end

--- a/src/base.jl
+++ b/src/base.jl
@@ -1681,11 +1681,9 @@ end
 
 function _validate_or_skip!(sys, component, skip_validation)
     if skip_validation && get_runchecks(sys)
-        Base.depwarn(
-            "skip_validation is deprecated; construct System with runchecks = true or call set_runchecks! instead",
-            :add_component!,
+        @warn(
+            "skip_validation is deprecated; construct System with runchecks = true or call set_runchecks!. Disabling System.runchecks"
         )
-        @warn "Disabling System.runchecks"
         set_runchecks!(sys, false)
     end
 

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -62,7 +62,7 @@ function System(pm_data::PowerModelsData; kwargs...)
     read_dcline!(sys, data, bus_number_to_bus; kwargs...)
     read_storage!(sys, data, bus_number_to_bus; kwargs...)
     if runchecks
-        check!(sys)
+        check(sys)
     end
     return sys
 end

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -287,7 +287,7 @@ function System(
         add_time_series!(sys, timeseries_metadata_file; resolution = time_series_resolution)
     end
 
-    check!(sys)
+    check(sys)
     return sys
 end
 

--- a/src/utils/IO/branchdata_checks.jl
+++ b/src/utils/IO/branchdata_checks.jl
@@ -1,13 +1,14 @@
 
-function validate_struct(sys::System, ps_struct::Union{MonitoredLine, Line})
+function correct_component!(line::Union{MonitoredLine, Line}, sys::System)
+    check_angle_limits!(line)
+end
+
+function validate_component_with_system(line::Union{MonitoredLine, Line}, sys::System)
     is_valid = true
-    if !check_endpoint_voltages(ps_struct)
+    if !check_endpoint_voltages(line)
         is_valid = false
-    else
-        check_angle_limits!(ps_struct)
-        if !calculate_thermal_limits!(ps_struct, get_base_power(sys))
-            is_valid = false
-        end
+    elseif !calculate_thermal_limits!(line, get_base_power(sys))
+        is_valid = false
     end
     return is_valid
 end

--- a/src/utils/IO/branchdata_checks.jl
+++ b/src/utils/IO/branchdata_checks.jl
@@ -1,6 +1,6 @@
 
-function correct_component!(line::Union{MonitoredLine, Line}, sys::System)
-    check_angle_limits!(line)
+function sanitize_component!(line::Union{MonitoredLine, Line}, sys::System)
+    sanitize_angle_limits!(line)
 end
 
 function validate_component_with_system(line::Union{MonitoredLine, Line}, sys::System)
@@ -13,7 +13,7 @@ function validate_component_with_system(line::Union{MonitoredLine, Line}, sys::S
     return is_valid
 end
 
-function check_angle_limits!(line)
+function sanitize_angle_limits!(line)
     max_limit = pi / 2
     min_limit = -pi / 2
 

--- a/test/test_branchchecks_testing.jl
+++ b/test/test_branchchecks_testing.jl
@@ -146,7 +146,7 @@ end
         ),
     ]
 
-    foreach(x -> PowerSystems.check_angle_limits!(x), branches_test)
+    foreach(x -> PowerSystems.sanitize_angle_limits!(x), branches_test)
 
     @test branches_test[1].angle_limits == (min = -pi / 2, max = pi / 2)
     @test branches_test[2].angle_limits == (min = -pi / 2, max = 75.0 * (π / 180))
@@ -170,6 +170,6 @@ end
 
     @test_throws(
         PowerSystems.DataFormatError,
-        PowerSystems.check_angle_limits!(bad_angle_limits)
+        PowerSystems.sanitize_angle_limits!(bad_angle_limits)
     )
 end

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -188,7 +188,7 @@ end
 
 @testset "Test system checks" begin
     sys = System(100)
-    @test_logs (:warn, r"There are no .* Components in the System") match_mode = :any PSY.check!(
+    @test_logs (:warn, r"There are no .* Components in the System") match_mode = :any check(
         sys,
     )
 end

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -340,6 +340,9 @@ end
         (:error, r"Invalid range"),
         (:warn, r"exceeds total capacity capability"),
         match_mode = :any,
-        @test_throws(IS.InvalidRange, to_json(sys, "sys.json", force = true, check = true)),
+        @test_throws(
+            IS.InvalidRange,
+            to_json(sys, "sys.json", force = true, runchecks = true)
+        ),
     )
 end


### PR DESCRIPTION
1. Makes `System.runchecks` the only way to control validation of components. Deprecates the use of `skip_validation` in `add_component!`.
2. Adds functions to check components. Exports those functions along with `check!`.
3. Fixes a bug where the kwarg runchecks was not honored during deserialization.

Dependent on this InfrastructureSystems PR: https://github.com/NREL-SIIP/InfrastructureSystems.jl/pull/194.