### PR TITLE
enabling the removal of system time series of a particular type

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -1085,7 +1085,7 @@ function clear_time_series!(sys::System)
 end
 
 """
-Remove the time series data for a component.
+Remove the time series data for a component and time series type.
 """
 function remove_time_series!(
     sys::System,
@@ -1094,6 +1094,16 @@ function remove_time_series!(
     name::String,
 ) where {T <: TimeSeriesData}
     return IS.remove_time_series!(sys.data, T, component, name)
+end
+
+"""
+Remove all the time series data for a time series type.
+"""
+function remove_time_series!(
+    sys::System,
+    ::Type{T}
+) where {T <: TimeSeriesData}
+    return IS.remove_time_series!(sys.data, T)
 end
 
 """

--- a/src/base.jl
+++ b/src/base.jl
@@ -1099,10 +1099,7 @@ end
 """
 Remove all the time series data for a time series type.
 """
-function remove_time_series!(
-    sys::System,
-    ::Type{T}
-) where {T <: TimeSeriesData}
+function remove_time_series!(sys::System, ::Type{T}) where {T <: TimeSeriesData}
     return IS.remove_time_series!(sys.data, T)
 end
 


### PR DESCRIPTION
This PR addresses an issue with the following workflow:
 - starting from a system with both `SingleTimeSeries` and `DeterministicSingleTimeSeries` (i.e. `transform_time_series` has been run)
 - if you want to add a new time series, you need to remove all the `<:Forecast` time series first
 - re-run `transform_time_series`