### PR TITLE
Preserve runchecks across deepcopy

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -262,7 +262,7 @@ function Base.deepcopy(sys::System)
     path = mktempdir()
     filename = joinpath(path, "sys.json")
     to_json(sys, filename)
-    return System(filename)
+    return System(filename, runchecks = get_runchecks(sys))
 end
 
 """

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -267,3 +267,19 @@ end
 @testset "Invalid constructor" begin
     @test_throws IS.DataFormatError System("data.invalid")
 end
+
+@testset "Test deepcopy with runchecks" begin
+    sys = System(100.0)
+    @test get_runchecks(sys)
+    @test_logs (:error, r"Model doesn't contain a slack bus") match_mode = :any @test get_runchecks(
+        deepcopy(sys),
+    )
+end
+
+@testset "Test deepcopy with runchecks disabled" begin
+    sys = System(100.0, runchecks = false)
+    @test !get_runchecks(sys)
+    sys2 = deepcopy(sys)
+    @test sys2 isa System
+    @test !get_runchecks(sys)
+end


### PR DESCRIPTION
Fixes #724 