### PR TITLE
Add full support for HybridSystem

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -74,6 +74,7 @@ export DynamicGenerator
 export DynamicInverter
 export DynamicBranch
 export HybridSystem
+export StaticInjectionSubystem
 export RegulationDevice
 
 #AVR Exports
@@ -237,6 +238,7 @@ export get_component
 export get_components
 export get_components_by_name
 export get_available_components
+export get_subcomponents
 export get_forecast_horizon
 export get_forecast_initial_timestamp
 export get_forecast_interval
@@ -429,6 +431,7 @@ include("definitions.jl")
 include("models/static_models.jl")
 include("models/dynamic_models.jl")
 include("models/injection.jl")
+include("models/static_injection_subsystem.jl")
 
 # Include utilities
 include("utils/logging.jl")

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -251,6 +251,7 @@ export get_time_series_values
 export get_time_series_names
 export get_next_time_series_array!
 export get_next_time
+export get_initial_timestamp
 export get_horizon
 export get_forecast_initial_times
 export get_forecast_total_period
@@ -380,12 +381,14 @@ import InfrastructureSystems:
     set_name!,
     iterate_windows,
     get_time_series,
+    has_time_series,
     get_time_series_array,
     get_time_series_timestamps,
     get_time_series_values,
     get_time_series_names,
     get_next_time_series_array!,
     get_next_time,
+    get_initial_timestamp,
     get_units_info,
     set_units_info!,
     to_json,

--- a/src/base.jl
+++ b/src/base.jl
@@ -1114,6 +1114,21 @@ function remove_time_series!(sys::System, ::Type{T}) where {T <: TimeSeriesData}
     return IS.remove_time_series!(sys.data, T)
 end
 
+function remove_time_series!(
+    sys::System,
+    ::Type{T},
+    subsystem::StaticInjectionSubystem,
+    subcomponent::Component,
+    name::String,
+) where {T <: TimeSeriesData}
+    return IS.remove_time_series!(
+        sys.data,
+        T,
+        subsystem,
+        make_unique_time_series_name(subsystem, subcomponent, name),
+    )
+end
+
 """
 Transform all instances of SingleTimeSeries to DeterministicSingleTimeSeries.
 """

--- a/src/models/HybridSystem.jl
+++ b/src/models/HybridSystem.jl
@@ -9,7 +9,7 @@ Each generator is a data structure that is defined by the following components:
 - [Storage](@ref PowerSystems.Storage)
 - [RenewableGen](@ref PowerSystems.RenewableGen)
 """
-mutable struct HybridSystem <: StaticInjection
+mutable struct HybridSystem <: StaticInjectionSubystem
     name::String
     available::Bool
     status::Bool
@@ -226,10 +226,42 @@ set_ext!(value::HybridSystem, val) = value.ext = val
 InfrastructureSystems.set_time_series_container!(value::HybridSystem, val) =
     value.time_series_container = val
 
-function IS.deserialize(::Type{HybridSystem}, data::Dict, component_cache::Dict)
-    error("Deserialization of HybridSystem is not currently supported")
+"""
+Return an iterator over the subcomponents in the HybridSystem.
+Call collect on the result if an array is desired.
+
+# Examples
+```julia
+for subcomponent in get_subcomponents(hybrid_sys)
+    @show subcomponent
 end
 
-function IS.serialize(component::HybridSystem)
-    error("Serialization of HybridSystem is not currently supported")
+subcomponents = collect(get_subcomponents(hybrid_sys))
+```
+"""
+function get_subcomponents(hybrid::HybridSystem)
+    Channel() do channel
+        for field in (:thermal_unit, :electric_load, :storage, :renewable_unit)
+            subcomponent = getfield(hybrid, field)
+            if subcomponent !== nothing
+                put!(channel, subcomponent)
+            end
+        end
+    end
+end
+
+function make_unique_time_series_name(
+    hybrid::HybridSystem,
+    subcomponent::Component,
+    time_series::TimeSeriesData,
+)
+    return make_unique_time_series_name(hybrid, subcomponent, get_name(time_series))
+end
+
+function make_unique_time_series_name(
+    hybrid::HybridSystem,
+    subcomponent::Component,
+    name::AbstractString,
+)
+    return join((string(typeof(subcomponent)), name), "__")
 end

--- a/src/models/HybridSystem.jl
+++ b/src/models/HybridSystem.jl
@@ -258,10 +258,23 @@ function make_unique_time_series_name(
     return make_unique_time_series_name(hybrid, subcomponent, get_name(time_series))
 end
 
+const _HYBRID_SYS_NAME_DELIMITER = "__"
+
 function make_unique_time_series_name(
     hybrid::HybridSystem,
     subcomponent::Component,
     name::AbstractString,
 )
-    return join((string(typeof(subcomponent)), name), "__")
+    return join((string(typeof(subcomponent)), name), _HYBRID_SYS_NAME_DELIMITER)
+end
+
+function does_time_series_name_match_subcomponent(hybrid::HybridSystem, subcomponent, name)
+    fields = split(name, _HYBRID_SYS_NAME_DELIMITER)
+    if length(fields) != 2
+        throw(
+            ArgumentError("$name is not valid for a HybridSystem subcomponent time series"),
+        )
+    end
+
+    return fields[1] == string(typeof(subcomponent))
 end

--- a/src/models/components.jl
+++ b/src/models/components.jl
@@ -57,7 +57,3 @@ end
 function get_value(::Nothing, _)
     return
 end
-
-function has_time_series(d::Component)
-    return IS.has_time_series(d)
-end

--- a/src/models/static_injection_subsystem.jl
+++ b/src/models/static_injection_subsystem.jl
@@ -8,12 +8,13 @@ Subtypes must implement:
       subcomponent::Component,
       name::AbstractString,
   )
+- does_time_series_name_match_subcomponent(hybrid::HybridSystem, subcomponent, name)
 
 The subcomponents in subtypes are not attached to the System.
 """
 abstract type StaticInjectionSubystem <: StaticInjection end
 
-function get_time_series(
+function IS.get_time_series(
     ::Type{T},
     subsystem::StaticInjectionSubystem,
     subcomponent::InfrastructureSystemsComponent,
@@ -30,4 +31,87 @@ function get_time_series(
         len = len,
         count = count,
     )
+end
+
+function IS.get_time_series_array(
+    ::Type{T},
+    subsystem::StaticInjectionSubystem,
+    subcomponent::InfrastructureSystemsComponent,
+    name::AbstractString;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
+    len::Union{Nothing, Int} = nothing,
+    ignore_scaling_factors = false,
+) where {T <: TimeSeriesData}
+    ts = get_time_series(
+        T,
+        subsystem,
+        make_unique_time_series_name(subsystem, subcomponent, name),
+        start_time = start_time,
+        len = len,
+    )
+    return get_time_series_array(
+        subcomponent,
+        ts,
+        get_initial_timestamp(ts),
+        len = len,
+        ignore_scaling_factors = ignore_scaling_factors,
+    )
+end
+
+function IS.get_time_series_values(
+    ::Type{T},
+    subsystem::StaticInjectionSubystem,
+    subcomponent::Component,
+    name::AbstractString;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
+    len::Union{Nothing, Int} = nothing,
+    ignore_scaling_factors = false,
+) where {T <: TimeSeriesData}
+    ts = get_time_series(
+        T,
+        subsystem,
+        make_unique_time_series_name(subsystem, subcomponent, name),
+        start_time = start_time,
+        len = len,
+    )
+    return get_time_series_values(
+        subcomponent,
+        ts,
+        get_initial_timestamp(ts),
+        len = len,
+        ignore_scaling_factors = ignore_scaling_factors,
+    )
+end
+
+function IS.get_time_series_timestamps(
+    ::Type{T},
+    subsystem::StaticInjectionSubystem,
+    subcomponent::Component,
+    name::AbstractString;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
+    len::Union{Nothing, Int} = nothing,
+) where {T <: TimeSeriesData}
+    ts = get_time_series(
+        T,
+        subsystem,
+        make_unique_time_series_name(subsystem, subcomponent, name),
+        start_time = start_time,
+        len = len,
+    )
+    return get_time_series_timestamps(
+        subcomponent,
+        ts,
+        get_initial_timestamp(ts),
+        len = len,
+    )
+end
+
+function IS.has_time_series(subsystem::StaticInjectionSubystem, subcomponent::Component)
+    for key in IS.get_time_series_keys(subsystem)
+        if does_time_series_name_match_subcomponent(subsystem, subcomponent, key.name)
+            return true
+        end
+    end
+
+    return false
 end

--- a/src/models/static_injection_subsystem.jl
+++ b/src/models/static_injection_subsystem.jl
@@ -1,0 +1,33 @@
+"""
+Abstract type for a subsystem that contains multiple instances of StaticInjection
+
+Subtypes must implement:
+- get_subcomponents(subsystem::StaticInjectionSubsystem)
+- make_unique_time_series_name(
+      subsystem::StaticInjectionSubsystem,
+      subcomponent::Component,
+      name::AbstractString,
+  )
+
+The subcomponents in subtypes are not attached to the System.
+"""
+abstract type StaticInjectionSubystem <: StaticInjection end
+
+function get_time_series(
+    ::Type{T},
+    subsystem::StaticInjectionSubystem,
+    subcomponent::InfrastructureSystemsComponent,
+    name::AbstractString;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
+    len::Union{Nothing, Int} = nothing,
+    count::Union{Nothing, Int} = nothing,
+) where {T <: TimeSeriesData}
+    return get_time_series(
+        T,
+        subsystem,
+        make_unique_time_series_name(subsystem, subcomponent, name),
+        start_time = start_time,
+        len = len,
+        count = count,
+    )
+end

--- a/test/common.jl
+++ b/test/common.jl
@@ -25,6 +25,37 @@ function create_rts_multistart_system(time_series_resolution = Dates.Hour(1))
     return System(data; time_series_resolution = time_series_resolution)
 end
 
+function create_rts_system_with_hybrid_system(; add_forecasts = true)
+    sys = PSB.build_system(
+        PSB.PSITestSystems,
+        "test_RTS_GMLC_sys",
+        add_forecasts = add_forecasts,
+    )
+    thermal_unit = first(get_components(ThermalStandard, sys))
+    bus = get_bus(thermal_unit)
+    electric_load = first(get_components(PowerLoad, sys))
+    storage = first(get_components(GenericBattery, sys))
+    renewable_unit = first(get_components(RenewableDispatch, sys))
+
+    name = "Test H"
+    h_sys = HybridSystem(
+        name = name,
+        available = true,
+        status = true,
+        bus = bus,
+        active_power = 1.0,
+        reactive_power = 1.0,
+        thermal_unit = thermal_unit,
+        electric_load = electric_load,
+        storage = storage,
+        renewable_unit = renewable_unit,
+        base_power = 100.0,
+        operation_cost = TwoPartCost(nothing),
+    )
+    add_component!(sys, h_sys)
+    return sys
+end
+
 """Allows comparison of structs that were created from different parsers which causes them
 to have different UUIDs."""
 function compare_values_without_uuids(x::T, y::T) where {T <: IS.InfrastructureSystemsType}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using Logging
+using Random
 using DataStructures
 using Dates
 using LinearAlgebra

--- a/test/test_hybrid_system.jl
+++ b/test/test_hybrid_system.jl
@@ -27,5 +27,81 @@
     add_time_series!(test_sys, h_sys, forecast)
     ts = get_time_series(Deterministic, h_sys, "test")
     @test isa(ts, Deterministic)
-    @test_throws ErrorException to_json(test_sys, "./test_sys.json", force = true)
+end
+
+@testset "Hybrid System from parsed files" begin
+    sys = create_rts_system_with_hybrid_system(add_forecasts = true)
+    hybrids = collect(get_components(HybridSystem, sys))
+    @test length(hybrids) == 1
+    h_sys = hybrids[1]
+
+    electric_load = nothing
+    subcomponents = collect(get_subcomponents(h_sys))
+    @test length(subcomponents) == 4
+    for subcomponent in subcomponents
+        @test !PSY.is_attached(subcomponent, sys)
+        if subcomponent isa PowerLoad
+            electric_load = subcomponent
+        end
+    end
+
+    sts = collect(get_time_series_multiple(h_sys, type = SingleTimeSeries))
+    @test length(sts) == 2
+    forecasts = collect(get_time_series_multiple(h_sys, type = AbstractDeterministic))
+    @test length(forecasts) == 2
+
+    @test get_time_series(SingleTimeSeries, h_sys, electric_load, "max_active_power") isa
+          SingleTimeSeries
+    @test get_time_series(SingleTimeSeries, h_sys, "PowerLoad__max_active_power") isa
+          SingleTimeSeries
+    @test get_time_series(
+        AbstractDeterministic,
+        h_sys,
+        electric_load,
+        "max_active_power",
+    ) isa DeterministicSingleTimeSeries
+    @test get_time_series(AbstractDeterministic, h_sys, "PowerLoad__max_active_power") isa
+          DeterministicSingleTimeSeries
+end
+
+@testset "Hybrid System from unattached subcomponents" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "test_RTS_GMLC_sys"; add_forecasts = false)
+    thermal_unit = first(get_components(ThermalStandard, sys))
+    bus = get_bus(thermal_unit)
+    electric_load = first(get_components(PowerLoad, sys))
+    storage = first(get_components(GenericBattery, sys))
+    renewable_unit = first(get_components(RenewableDispatch, sys))
+
+    for subcomponent in (thermal_unit, electric_load, storage, renewable_unit)
+        remove_component!(sys, subcomponent)
+    end
+
+    name = "Test H"
+    h_sys = HybridSystem(
+        name = name,
+        available = true,
+        status = true,
+        bus = bus,
+        active_power = 1.0,
+        reactive_power = 1.0,
+        thermal_unit = thermal_unit,
+        electric_load = electric_load,
+        storage = storage,
+        renewable_unit = renewable_unit,
+        base_power = 100.0,
+        operation_cost = TwoPartCost(nothing),
+    )
+    add_component!(sys, h_sys)
+
+    # Add time series for a subcomponent.
+    initial_time = Dates.DateTime("2020-09-01")
+    resolution = Dates.Hour(1)
+    other_time = initial_time + resolution
+    name = "test"
+    horizon = 24
+    data = Dict(initial_time => ones(horizon), other_time => 5.0 * ones(horizon))
+    forecast = Deterministic(name, data, resolution)
+    add_time_series!(sys, h_sys, thermal_unit, forecast)
+    @test get_time_series(Deterministic, h_sys, thermal_unit, "test") isa Deterministic
+    @test get_time_series(Deterministic, h_sys, "ThermalStandard__test") isa Deterministic
 end

--- a/test/test_hybrid_system.jl
+++ b/test/test_hybrid_system.jl
@@ -62,6 +62,10 @@ end
     ) isa DeterministicSingleTimeSeries
     @test get_time_series(AbstractDeterministic, h_sys, "PowerLoad__max_active_power") isa
           DeterministicSingleTimeSeries
+
+    remove_time_series!(sys, SingleTimeSeries, h_sys, electric_load, "max_active_power")
+    sts = collect(get_time_series_multiple(h_sys, type = SingleTimeSeries))
+    @test length(sts) == 1
 end
 
 @testset "Hybrid System from unattached subcomponents" begin

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -191,3 +191,9 @@ end
     _, result = validate_serialization(sys)
     @test result
 end
+
+@testset "Test JSON serialization of HybridSystem" begin
+    sys = create_rts_system_with_hybrid_system(add_forecasts = true)
+    sys2, result = validate_serialization(sys)
+    @test result
+end


### PR DESCRIPTION
- Add supertype StaticInjectionSubystem.
- Add support for time series at the subcomponent level.
- Add serialization support.

This will allow construction of a HybridSystem with subcomponents that are either attached or not attached to the system. If they are attached, they are removed. If they have time series, those are moved to the HybridSystem.

All time series methods are now implemented or intentionally left out except
- ForecastCache
- StaticTimeSeriesCache

Solving that will be ugly. Let's talk @claytonpbarrows @jd-lara 

Also, I had to change the time series storage code in IS. Now this PR is dependent on the following IS PR: https://github.com/NREL-SIIP/InfrastructureSystems.jl/pull/218 