### PR TITLE
Add full support for HybridSystems

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -23,6 +23,7 @@ export get_max_active_power
 export get_max_reactive_power
 export Branch
 export StaticInjection
+export StaticInjectionSubsystem
 export ACBranch
 export Line
 export MonitoredLine
@@ -235,6 +236,7 @@ export ServiceContributingDevicesKey
 export ServiceContributingDevicesMapping
 export get_component
 export get_components
+export get_subcomponents
 export get_components_by_name
 export get_available_components
 export get_forecast_horizon
@@ -429,6 +431,7 @@ include("definitions.jl")
 include("models/static_models.jl")
 include("models/dynamic_models.jl")
 include("models/injection.jl")
+include("models/static_injection_subsystem.jl")
 
 # Include utilities
 include("utils/logging.jl")

--- a/src/base.jl
+++ b/src/base.jl
@@ -1234,7 +1234,7 @@ function IS.deserialize(
 
     ext = get_ext(sys)
     ext["deserialization_in_progress"] = true
-    deserialize_components!(sys, raw["data"]["components"])
+    deserialize_components!(sys, raw["data"])
     pop!(ext, "deserialization_in_progress")
     isempty(ext) && clear_ext!(sys)
 
@@ -1252,7 +1252,7 @@ end
 function deserialize_components!(sys::System, raw)
     # Convert the array of components into type-specific arrays to allow addition by type.
     data = Dict{Any, Vector{Dict}}()
-    for component in raw
+    for component in Iterators.Flatten((raw["components"], raw["masked_components"]))
         type = IS.get_type_from_serialization_data(component)
         components = get(data, type, nothing)
         if components === nothing
@@ -1310,7 +1310,17 @@ function deserialize_components!(sys::System, raw)
     deserialize_and_add!(; include_types = [DynamicBranch])
     # Static injection devices can contain dynamic injection devices.
     deserialize_and_add!(; include_types = [StaticReserveGroup, DynamicInjection])
+    # StaticInjectionSubsystem instances have StaticInjection subcomponents.
+    deserialize_and_add!(; skip_types = [StaticInjectionSubsystem])
     deserialize_and_add!()
+
+    for subsystem in get_components(StaticInjectionSubsystem, sys)
+        # This normally happens when the subsytem is added to the system.
+        # Workaround for deserialization.
+        for subcomponent in get_subcomponents(subsystem)
+            IS.mask_component!(sys.data, subcomponent)
+        end
+    end
 end
 
 """
@@ -1506,6 +1516,20 @@ function handle_component_addition!(sys::System, dyn_injector::DynamicInjection;
     static_base_power = get_base_power(static_injector)
     set_base_power!(dyn_injector, static_base_power)
     set_dynamic_injector!(static_injector, dyn_injector)
+end
+
+function handle_component_addition!(
+    sys::System,
+    subsystem::StaticInjectionSubsystem;
+    kwargs...,
+)
+    for subcomponent in get_subcomponents(subsystem)
+        if is_attached(subcomponent, sys)
+            IS.mask_component!(sys.data, subcomponent)
+        else
+            IS.add_masked_component!(sys.data, subcomponent)
+        end
+    end
 end
 
 function handle_component_addition_common!(sys::System, component::Branch)

--- a/src/base.jl
+++ b/src/base.jl
@@ -383,7 +383,7 @@ function add_component!(
     IS.add_component!(
         sys.data,
         component;
-        deserialization_in_progress = deserialization_in_progress,
+        allow_existing_time_series = deserialization_in_progress,
         skip_validation = skip_validation,
         _kwargs...,
     )

--- a/src/models/HybridSystem.jl
+++ b/src/models/HybridSystem.jl
@@ -195,14 +195,6 @@ set_interconnection_rating!(value::HybridSystem, val) = value.interconnection_ra
 set_active_power!(value::HybridSystem, val) = value.active_power = val
 """Set [`HybridSystem`](@ref) `reactive_power`."""
 set_reactive_power!(value::HybridSystem, val) = value.reactive_power = val
-"""Get [`HybridSystem`](@ref) thermal unit"""
-set_thermal_unit!(value::HybridSystem, val::ThermalGen) = value.thermal_unit = val
-"""Get [`HybridSystem`](@ref) load"""
-set_electric_load!(value::HybridSystem, val::ElectricLoad) = value.electric_load = val
-"""Get [`HybridSystem`](@ref) storage unit"""
-set_storage!(value::HybridSystem, val::Storage) = value.storage = val
-"""Get [`HybridSystem`](@ref) renewable unit"""
-set_renewable_unit!(value::HybridSystem, val::RenewableGen) = value.renewable_unit = val
 """set [`HybridSystem`](@ref) interconnection impedance"""
 set_interconnection_impedance!(value::HybridSystem, val) =
     value.interconnection_impedance = val
@@ -245,5 +237,39 @@ function get_subcomponents(hybrid::HybridSystem)
                 put!(channel, subcomponent)
             end
         end
+    end
+end
+
+"""Set [`HybridSystem`](@ref) thermal unit"""
+function set_thermal_unit!(hybrid::HybridSystem, val::ThermalGen)
+    _raise_if_attached_to_system(hybrid)
+    hybrid.thermal_unit = val
+end
+
+"""Set [`HybridSystem`](@ref) load"""
+function set_electric_load!(hybrid::HybridSystem, val::ElectricLoad)
+    _raise_if_attached_to_system(hybrid)
+    value.electric_load = val
+end
+
+"""Set [`HybridSystem`](@ref) storage unit"""
+function set_storage!(hybrid::HybridSystem, val::Storage)
+    _raise_if_attached_to_system(hybrid)
+    value.storage = val
+end
+
+"""Set [`HybridSystem`](@ref) renewable unit"""
+function set_renewable_unit!(hybrid::HybridSystem, val::RenewableGen)
+    _raise_if_attached_to_system(hybrid)
+    value.renewable_unit = val
+end
+
+function _raise_if_attached_to_system(hybrid::HybridSystem)
+    if hybrid.time_series_container.time_series_storage !== nothing
+        throw(
+            ArgumentError(
+                "Operation not allowed because the HybridSystem is attached to a system",
+            ),
+        )
     end
 end

--- a/src/models/HybridSystem.jl
+++ b/src/models/HybridSystem.jl
@@ -9,7 +9,7 @@ Each generator is a data structure that is defined by the following components:
 - [Storage](@ref PowerSystems.Storage)
 - [RenewableGen](@ref PowerSystems.RenewableGen)
 """
-mutable struct HybridSystem <: StaticInjection
+mutable struct HybridSystem <: StaticInjectionSubsystem
     name::String
     available::Bool
     status::Bool
@@ -226,10 +226,24 @@ set_ext!(value::HybridSystem, val) = value.ext = val
 InfrastructureSystems.set_time_series_container!(value::HybridSystem, val) =
     value.time_series_container = val
 
-function IS.deserialize(::Type{HybridSystem}, data::Dict, component_cache::Dict)
-    error("Deserialization of HybridSystem is not currently supported")
-end
+"""
+Return an iterator over the subcomponents in the HybridSystem.
 
-function IS.serialize(component::HybridSystem)
-    error("Serialization of HybridSystem is not currently supported")
+# Examples
+```julia
+for subcomponent in get_subcomponents(hybrid_sys)
+    @show subcomponent
+end
+subcomponents = collect(get_subcomponents(hybrid_sys))
+```
+"""
+function get_subcomponents(hybrid::HybridSystem)
+    Channel() do channel
+        for field in (:thermal_unit, :electric_load, :storage, :renewable_unit)
+            subcomponent = getfield(hybrid, field)
+            if subcomponent !== nothing
+                put!(channel, subcomponent)
+            end
+        end
+    end
 end

--- a/src/models/static_injection_subsystem.jl
+++ b/src/models/static_injection_subsystem.jl
@@ -1,0 +1,9 @@
+"""
+Abstract type for a subsystem that contains multiple instances of StaticInjection
+
+Subtypes must implement:
+- get_subcomponents(subsystem::StaticInjectionSubsystem)
+
+The subcomponents in subtypes must be attached to the System as masked components.
+"""
+abstract type StaticInjectionSubsystem <: StaticInjection end

--- a/test/common.jl
+++ b/test/common.jl
@@ -25,6 +25,37 @@ function create_rts_multistart_system(time_series_resolution = Dates.Hour(1))
     return System(data; time_series_resolution = time_series_resolution)
 end
 
+function create_rts_system_with_hybrid_system(; add_forecasts = true)
+    sys = PSB.build_system(
+        PSB.PSITestSystems,
+        "test_RTS_GMLC_sys",
+        add_forecasts = add_forecasts,
+    )
+    thermal_unit = first(get_components(ThermalStandard, sys))
+    bus = get_bus(thermal_unit)
+    electric_load = first(get_components(PowerLoad, sys))
+    storage = first(get_components(GenericBattery, sys))
+    renewable_unit = first(get_components(RenewableDispatch, sys))
+
+    name = "Test H"
+    h_sys = HybridSystem(
+        name = name,
+        available = true,
+        status = true,
+        bus = bus,
+        active_power = 1.0,
+        reactive_power = 1.0,
+        thermal_unit = thermal_unit,
+        electric_load = electric_load,
+        storage = storage,
+        renewable_unit = renewable_unit,
+        base_power = 100.0,
+        operation_cost = TwoPartCost(nothing),
+    )
+    add_component!(sys, h_sys)
+    return sys
+end
+
 """Allows comparison of structs that were created from different parsers which causes them
 to have different UUIDs."""
 function compare_values_without_uuids(x::T, y::T) where {T <: IS.InfrastructureSystemsType}

--- a/test/test_hybrid_system.jl
+++ b/test/test_hybrid_system.jl
@@ -27,5 +27,91 @@
     add_time_series!(test_sys, h_sys, forecast)
     ts = get_time_series(Deterministic, h_sys, "test")
     @test isa(ts, Deterministic)
-    @test_throws ErrorException to_json(test_sys, "./test_sys.json", force = true)
+end
+
+@testset "Hybrid System from parsed files" begin
+    sys = create_rts_system_with_hybrid_system(add_forecasts = true)
+    hybrids = collect(get_components(HybridSystem, sys))
+    @test length(hybrids) == 1
+    h_sys = hybrids[1]
+
+    electric_load = nothing
+    thermal_unit = nothing
+    subcomponents = collect(get_subcomponents(h_sys))
+    @test length(subcomponents) == 4
+    for subcomponent in subcomponents
+        @test !PSY.is_attached(subcomponent, sys)
+        @test IS.is_attached(subcomponent, sys.data.masked_components)
+        if subcomponent isa PowerLoad
+            electric_load = subcomponent
+        elseif subcomponent isa ThermalStandard
+            thermal_unit = subcomponent
+        end
+    end
+    @test electric_load !== nothing
+    @test thermal_unit !== nothing
+
+    ts = collect(get_time_series_multiple(h_sys, type = TimeSeriesData))
+    @test length(ts) == 0
+
+    @test get_time_series(SingleTimeSeries, electric_load, "max_active_power") isa
+          SingleTimeSeries
+    @test get_time_series(AbstractDeterministic, electric_load, "max_active_power") isa
+          DeterministicSingleTimeSeries
+
+    @test !has_time_series(thermal_unit)
+    @test has_time_series(electric_load)
+    remove_time_series!(sys, AbstractDeterministic, electric_load, "max_active_power")
+    remove_time_series!(sys, SingleTimeSeries, electric_load, "max_active_power")
+    @test !has_time_series(electric_load)
+end
+
+@testset "Hybrid System from unattached subcomponents" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "test_RTS_GMLC_sys"; add_forecasts = false)
+    thermal_unit = first(get_components(ThermalStandard, sys))
+    bus = get_bus(thermal_unit)
+    electric_load = first(get_components(PowerLoad, sys))
+    storage = first(get_components(GenericBattery, sys))
+    renewable_unit = first(get_components(RenewableDispatch, sys))
+
+    for subcomponent in (thermal_unit, electric_load, storage, renewable_unit)
+        remove_component!(sys, subcomponent)
+    end
+
+    name = "Test H"
+    h_sys = HybridSystem(
+        name = name,
+        available = true,
+        status = true,
+        bus = bus,
+        active_power = 1.0,
+        reactive_power = 1.0,
+        thermal_unit = thermal_unit,
+        electric_load = electric_load,
+        storage = storage,
+        renewable_unit = renewable_unit,
+        base_power = 100.0,
+        operation_cost = TwoPartCost(nothing),
+    )
+    add_component!(sys, h_sys)
+
+    for subcomponent in (thermal_unit, electric_load, storage, renewable_unit)
+        @test !PSY.is_attached(subcomponent, sys)
+        @test !has_time_series(subcomponent)
+        @test IS.is_attached(subcomponent, sys.data.masked_components)
+    end
+
+    @test length(IS.get_masked_components(Component, sys.data)) == 4
+
+    # Add time series for a subcomponent.
+    initial_time = Dates.DateTime("2020-09-01")
+    resolution = Dates.Hour(1)
+    other_time = initial_time + resolution
+    name = "test"
+    horizon = 24
+    data = Dict(initial_time => rand(horizon), other_time => 5.0 * ones(horizon))
+
+    forecast = Deterministic(name, data, resolution)
+    add_time_series!(sys, thermal_unit, forecast)
+    @test get_time_series(Deterministic, thermal_unit, name) isa Deterministic
 end

--- a/test/test_hybrid_system.jl
+++ b/test/test_hybrid_system.jl
@@ -64,6 +64,9 @@ end
     remove_time_series!(sys, AbstractDeterministic, electric_load, "max_active_power")
     remove_time_series!(sys, SingleTimeSeries, electric_load, "max_active_power")
     @test !has_time_series(electric_load)
+
+    # Can't set the units when the HybridSystem is attached to system.
+    @test_throws ArgumentError PSY.set_thermal_unit!(h_sys, thermal_unit)
 end
 
 @testset "Hybrid System from unattached subcomponents" begin

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -191,3 +191,18 @@ end
     _, result = validate_serialization(sys)
     @test result
 end
+
+@testset "Test JSON serialization of HybridSystem" begin
+    sys = create_rts_system_with_hybrid_system(add_forecasts = true)
+    h_sys = first(get_components(HybridSystem, sys))
+    subcomponents = collect(get_subcomponents(h_sys))
+    @test length(subcomponents) == 4
+    sys2, result = validate_serialization(sys)
+    @test result
+    subcomponent = subcomponents[1]
+    @test IS.get_masked_component(
+        typeof(subcomponent),
+        sys2.data,
+        get_name(subcomponent),
+    ) !== nothing
+end


### PR DESCRIPTION
This PR adds the following functionality for HybridSystems:

- Add supertype StaticInjectionSubystem.
- Perform the `mask_component!` operation on subcomponents when the Hybrid is added to the system. This allows all time series methods to work on the subcomponents.
- Add serialization support.
