### PR TITLE
Allow passing single `start_up` value

### DIFF
--- a/src/models/supplemental_constructors.jl
+++ b/src/models/supplemental_constructors.jl
@@ -8,6 +8,23 @@ function ThreePartCost(variable_cost::T, args...) where {T <: VarCostArgs}
     return ThreePartCost(VariableCost(variable_cost), args...)
 end
 
+"""
+Accepts a single `start_up` value to use as the `hot` value, with `warm` and `cold` set to
+`0.0`.
+"""
+function MarketBidCost(
+    no_load,
+    start_up::Number,
+    shut_down,
+    variable = nothing,
+    ancillary_services = Vector{Service}(),
+)
+    # Intended for use with generators that are not multi-start (e.g. ThermalStandard).
+    # Operators use `hot` when they don’t have multiple stages.
+    start_up_multi = (hot = start_up, warm = 0.0, cold = 0.0)
+    return MarketBidCost(no_load, start_up_multi, shut_down, variable, ancillary_services)
+end
+
 # FIXME: This function name implies that will return a struct named `PowerLoadPF`
 # i.e. `PowerLoadPF` is not a constructor
 function PowerLoadPF(

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -66,8 +66,8 @@ end
 end
 
 @testset "Test MarketBidCost with single `start_up::Number` value" begin
-    expected = (hot=1.0, warm=0.0, cold=0.0)  # should only be used for the `hot` value.
-    cost = MarketBidCost(; start_up=1, no_load=rand(), shut_down=rand())
+    expected = (hot = 1.0, warm = 0.0, cold = 0.0)  # should only be used for the `hot` value.
+    cost = MarketBidCost(; start_up = 1, no_load = rand(), shut_down = rand())
     @test cost.start_up == expected
 end
 

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -65,6 +65,12 @@ end
     @test first(TimeSeries.values(cost_forecast)).cost == first(data_pwl[initial_time])
 end
 
+@testset "Test MarketBidCost with single `start_up::Number` value" begin
+    expected = (hot=1.0, warm=0.0, cold=0.0)  # should only be used for the `hot` value.
+    cost = MarketBidCost(; start_up=1, no_load=rand(), shut_down=rand())
+    @test cost.start_up == expected
+end
+
 @testset "Test ReserveDemandCurve with Cost Timeseries" begin
     initial_time = Dates.DateTime("2020-01-01")
     resolution = Dates.Hour(1)

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -68,7 +68,7 @@ end
 @testset "Test MarketBidCost with single `start_up::Number` value" begin
     expected = (hot = 1.0, warm = 0.0, cold = 0.0)  # should only be used for the `hot` value.
     cost = MarketBidCost(; start_up = 1, no_load = rand(), shut_down = rand())
-    @test cost.start_up == expected
+    @test get_start_up(cost) == expected
 end
 
 @testset "Test ReserveDemandCurve with Cost Timeseries" begin


### PR DESCRIPTION
For easier use with generators that are not multi-stage

Based on a [slack conversation](https://app.slack.com/client/T018DC9RCDV/C019J02EHNU/thread/C018SP6N7SR-1620141073.002600). This allows passing a single `start_up` value to `MarketBidCost`, for easier use with generators that are not multi-stage. We still repesent start-up costs internally as a NamedTuple (with hot/warn/cold values, as in the Market Bid Forms), but allow passing a single value that sets only the `hot` value, because this is what operators use when they don’t have multiple stages.

- i ran the formatter, but let me know if there are any style comments. 
- i use `cost.start_up` in the tests because equality is not defined on `MarketBidCost` (so couldn't do `MarketBidCost(; startup=X, ...) == MarketBidCost(; startup=(hot=X, ...), ...)`)
- What is the convention for bumping versions in the PR ? Shall i add a commit to bump the version from v1.4.2 -> v1.5.0?
