### PR TITLE
Improve `set_service_bid!` performance by avoiding `get_contributing_devices`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PowerSystems"
 uuid = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 authors = ["Jose Daniel Lara", "Daniel Thom", "Dheepak Krishnamurthy", "Clayton Barrows"]
-version = "1.4.3"
+version = "1.4.4"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -167,12 +167,12 @@ function set_service_bid!(
     service::Service,
     time_series_data::IS.TimeSeriesData,
 )
-    if get_name(time_series_data) != get_name(service)
-        error(
-            "Name provided in the TimeSeries Data $(get_name(time_series_data)), doesn't match the Service $(get_name(service)).",
-        )
-    end
-    verify_device_eligibility(sys, component, service)
+#     if get_name(time_series_data) != get_name(service)
+#         error(
+#             "Name provided in the TimeSeries Data $(get_name(time_series_data)), doesn't match the Service $(get_name(service)).",
+#         )
+#     end
+#     verify_device_eligibility(sys, component, service)
     add_time_series!(sys, component, time_series_data)
     ancillary_services = get_ancillary_services(get_operation_cost(component))
     push!(ancillary_services, service)

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -167,12 +167,12 @@ function set_service_bid!(
     service::Service,
     time_series_data::IS.TimeSeriesData,
 )
-#     if get_name(time_series_data) != get_name(service)
-#         error(
-#             "Name provided in the TimeSeries Data $(get_name(time_series_data)), doesn't match the Service $(get_name(service)).",
-#         )
-#     end
-#     verify_device_eligibility(sys, component, service)
+    if get_name(time_series_data) != get_name(service)
+        error(
+            "Name provided in the TimeSeries Data $(get_name(time_series_data)), doesn't match the Service $(get_name(service)).",
+        )
+    end
+    verify_device_eligibility(sys, component, service)
     add_time_series!(sys, component, time_series_data)
     ancillary_services = get_ancillary_services(get_operation_cost(component))
     push!(ancillary_services, service)
@@ -192,8 +192,7 @@ function verify_device_eligibility(
     component::StaticInjection,
     service::Service,
 )
-    contributing_devices = get_contributing_devices(sys, service)
-    if !in(component, contributing_devices)
+    if !has_service(component, service)
         error(
             "Device $(get_name(component)) isn't eligible to contribute to service $(get_name(service)).",
         )


### PR DESCRIPTION
Closes https://github.com/NREL-SIIP/PowerSystems.jl/issues/736.

Fixes the performance issues with `set_service_bid!` due to the checks involving `get_contributing_devices`. Thanks @daniel-thom for devising the solution.