### PR TITLE
Add error message when calculating PTDF for a system without reference bus

### DIFF
--- a/src/utils/network_calculations/ptdf_calculations.jl
+++ b/src/utils/network_calculations/ptdf_calculations.jl
@@ -46,6 +46,8 @@ function _buildptdf(branches, nodes, dist_slack::Vector{Float64})
     end
 
     slacks = [bus_lookup[get_number(n)] for n in nodes if get_bustype(n) == BusTypes.REF]
+    isempty(slacks) && error("System must have a reference bus!")
+
     slack_position = slacks[1]
     B = gemm(
         'N',


### PR DESCRIPTION
Currently it just throws an enigmatic `BoundsError: attempt to access 0-element Vector{Int64} at index [1]`.