### PR TITLE
Optimize deepcopy of System

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -259,14 +259,13 @@ function IS.to_json(sys::System, filename::AbstractString; force = false, runche
 end
 
 function Base.deepcopy(sys::System)
-    # We store time series in an HDF5 file that would not be copied as part of deepcopy.
-    # The HDF5 file could have data buffered in memory, so we would have to close it, make
-    # a copy, and attach it to a new system.
-    # A simpler solution is to serialize to a tmp dir and deserialize.
-    path = mktempdir()
-    filename = joinpath(path, "sys.json")
-    to_json(sys, filename)
-    return System(filename, runchecks = get_runchecks(sys))
+    sys2 = Base.deepcopy_internal(sys, IdDict())
+    if sys.data.time_series_storage isa IS.InMemoryTimeSeriesStorage
+        return sys2
+    end
+
+    IS.copy_to_new_file!(sys2.data.time_series_storage)
+    return sys2
 end
 
 """


### PR DESCRIPTION
This PR fixes #762. It will also make deepcopy of a system with HDF5 time series data much faster because there will not be a serialize and deserialize.

This requires https://github.com/NREL-SIIP/InfrastructureSystems.jl/pull/242. CI will fail until a new IS tag is available. The Project.toml will have to require that new tag.