### PR TITLE
add V_ref to SEXS struct

### DIFF
--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -3542,6 +3542,17 @@
           "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
         },
         {
+          "name": "V_ref",
+          "comment": "Reference Voltage Set-point",
+          "null_value": 0,
+          "default": "1.0",
+          "data_type": "Float64",
+          "valid_range": {
+            "min": 0,
+            "max": null
+          }
+        },
+        {
           "name": "ext",
           "data_type": "Dict{String, Any}",
           "null_value": "Dict{String, Any}()",

--- a/src/models/generated/SEXS.jl
+++ b/src/models/generated/SEXS.jl
@@ -8,6 +8,7 @@ This file is auto-generated. Do not edit.
         K::Float64
         Te::Float64
         V_lim::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
+        V_ref::Float64
         ext::Dict{String, Any}
         states::Vector{Symbol}
         n_states::Int
@@ -23,6 +24,7 @@ Parameters of Simplified Excitation System Model - SEXS in PSSE
 - `K::Float64`: Gain, validation range: `(0, nothing)`
 - `Te::Float64`: Field circuit time constant in s, validation range: `(0, nothing)`
 - `V_lim::NamedTuple{(:min, :max), Tuple{Float64, Float64}}`: Field voltage limits
+- `V_ref::Float64`: Reference Voltage Set-point, validation range: `(0, nothing)`
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: The states are:	Vf: Voltage field,	Vr: Lead-lag state
 - `n_states::Int`: SEXS has 2 states
@@ -40,6 +42,8 @@ mutable struct SEXS <: AVR
     Te::Float64
     "Field voltage limits"
     V_lim::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
+    "Reference Voltage Set-point"
+    V_ref::Float64
     ext::Dict{String, Any}
     "The states are:	Vf: Voltage field,	Vr: Lead-lag state"
     states::Vector{Symbol}
@@ -51,12 +55,12 @@ mutable struct SEXS <: AVR
     internal::InfrastructureSystemsInternal
 end
 
-function SEXS(Ta_Tb, Tb, K, Te, V_lim, ext=Dict{String, Any}(), )
-    SEXS(Ta_Tb, Tb, K, Te, V_lim, ext, [:Vf, :Vr], 2, [StateTypes.Differential, StateTypes.Differential], InfrastructureSystemsInternal(), )
+function SEXS(Ta_Tb, Tb, K, Te, V_lim, V_ref=1.0, ext=Dict{String, Any}(), )
+    SEXS(Ta_Tb, Tb, K, Te, V_lim, V_ref, ext, [:Vf, :Vr], 2, [StateTypes.Differential, StateTypes.Differential], InfrastructureSystemsInternal(), )
 end
 
-function SEXS(; Ta_Tb, Tb, K, Te, V_lim, ext=Dict{String, Any}(), states=[:Vf, :Vr], n_states=2, states_types=[StateTypes.Differential, StateTypes.Differential], internal=InfrastructureSystemsInternal(), )
-    SEXS(Ta_Tb, Tb, K, Te, V_lim, ext, states, n_states, states_types, internal, )
+function SEXS(; Ta_Tb, Tb, K, Te, V_lim, V_ref=1.0, ext=Dict{String, Any}(), states=[:Vf, :Vr], n_states=2, states_types=[StateTypes.Differential, StateTypes.Differential], internal=InfrastructureSystemsInternal(), )
+    SEXS(Ta_Tb, Tb, K, Te, V_lim, V_ref, ext, states, n_states, states_types, internal, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -67,6 +71,7 @@ function SEXS(::Nothing)
         K=0,
         Te=0,
         V_lim=(min=0.0, max=0.0),
+        V_ref=0,
         ext=Dict{String, Any}(),
     )
 end
@@ -81,6 +86,8 @@ get_K(value::SEXS) = value.K
 get_Te(value::SEXS) = value.Te
 """Get [`SEXS`](@ref) `V_lim`."""
 get_V_lim(value::SEXS) = value.V_lim
+"""Get [`SEXS`](@ref) `V_ref`."""
+get_V_ref(value::SEXS) = value.V_ref
 """Get [`SEXS`](@ref) `ext`."""
 get_ext(value::SEXS) = value.ext
 """Get [`SEXS`](@ref) `states`."""
@@ -102,6 +109,8 @@ set_K!(value::SEXS, val) = value.K = val
 set_Te!(value::SEXS, val) = value.Te = val
 """Set [`SEXS`](@ref) `V_lim`."""
 set_V_lim!(value::SEXS, val) = value.V_lim = val
+"""Set [`SEXS`](@ref) `V_ref`."""
+set_V_ref!(value::SEXS, val) = value.V_ref = val
 """Set [`SEXS`](@ref) `ext`."""
 set_ext!(value::SEXS, val) = value.ext = val
 """Set [`SEXS`](@ref) `states_types`."""


### PR DESCRIPTION
Fix a bug in SEXS struct that should have V_ref.