### PR TITLE
Compare values

### DIFF
--- a/docs/src/modeler_guide/system.md
+++ b/docs/src/modeler_guide/system.md
@@ -117,6 +117,21 @@ The serialization process stores 3 files
 2. Validation data file (`*.json` file)
 3. Time Series data file (`*.h5` file)
 
+To deserialize:
+
+```julia
+system2 = System("system.json")
+```
+
+PowerSystems generates UUIDs for the System and all components in order to have
+a way to uniquely identify objects. During deserialization it restores the same
+UUIDs.  If you will modify the System or components after deserialization then
+it is recommended that you set this flag to generate new UUIDs.
+
+```julia
+system2 = System("system.json", assign_new_uuids = true)
+```
+
 ## Reducing REPL printing
 
 By default `PowerSystems.jl` outputs to the REPL all Logging values, this can be overwhelming

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -415,6 +415,7 @@ import InfrastructureSystems:
     serialize,
     deserialize,
     get_time_series_multiple,
+    compare_values,
     CompressionSettings,
     CompressionTypes,
     NormalizationFactor,

--- a/src/base.jl
+++ b/src/base.jl
@@ -1656,60 +1656,47 @@ function get_bus_numbers(sys::System)
     return sort(collect(sys.bus_numbers))
 end
 
-function IS.compare_values(x::System, y::System)
-    match = true
-
-    if x.units_settings.unit_system != x.units_settings.unit_system
-        @debug "unit system does not match" _group = IS.LOG_GROUP_SERIALIZATION x.units_settings.unit_system y.units_settings.unit_system
-        match = false
-    end
-
-    if get_base_power(x) != get_base_power(y)
-        @debug "base_power does not match" _group = IS.LOG_GROUP_SERIALIZATION get_base_power(
-            x,
-        ) get_base_power(y)
-        match = false
-    end
-
-    if !IS.compare_values(x.data, y.data)
-        @debug "SystemData values do not match" _group = IS.LOG_GROUP_SERIALIZATION
-        match = false
-    end
-
-    return match
-end
-
-function IS.compare_values(x::T, y::T) where {T <: Union{StaticInjection, DynamicInjection}}
+function IS.compare_values(
+    x::T,
+    y::T;
+    compare_uuids = false,
+) where {T <: Union{StaticInjection, DynamicInjection}}
     # Must implement this method because a device of one of these subtypes might have a
     # reference to its counterpart, and vice versa, and so infinite recursion will occur
     # in the default function.
     match = true
-    for (fieldname, fieldtype) in zip(fieldnames(T), fieldtypes(T))
-        val1 = getfield(x, fieldname)
-        val2 = getfield(y, fieldname)
+    for name in fieldnames(T)
+        val1 = getfield(x, name)
+        val2 = getfield(y, name)
         if val1 isa StaticInjection || val2 isa DynamicInjection
-            uuid1 = IS.get_uuid(val1)
-            uuid2 = IS.get_uuid(val2)
-            if uuid1 != uuid2
-                @debug "values do not match" _group = IS.LOG_GROUP_SERIALIZATION T fieldname uuid1 uuid2
-                match = false
-                break
+            if !compare_uuids
+                name1 = get_name(val1)
+                name2 = get_name(val2)
+                if name1 != name2
+                    @error "values do not match" T name name1 name2
+                    match = false
+                end
+            else
+                uuid1 = IS.get_uuid(val1)
+                uuid2 = IS.get_uuid(val2)
+                if uuid1 != uuid2
+                    @error "values do not match" T name uuid1 uuid2
+                    match = false
+                end
             end
         elseif !isempty(fieldnames(typeof(val1)))
-            if !IS.compare_values(val1, val2)
-                @debug "values do not match" _group = IS.LOG_GROUP_SERIALIZATION T fieldname val1 val2
+            if !IS.compare_values(val1, val2, compare_uuids = compare_uuids)
+                @error "values do not match" T name val1 val2
                 match = false
-                break
             end
         elseif val1 isa AbstractArray
-            if !IS.compare_values(val1, val2)
+            if !IS.compare_values(val1, val2, compare_uuids = compare_uuids)
                 match = false
             end
         else
             if val1 != val2
-                @debug "values do not match" _group = IS.LOG_GROUP_SERIALIZATION T fieldname val1 val2
+                @error "values do not match" T name val1 val2
                 match = false
-                break
             end
         end
     end

--- a/test/test_power_system_table_data.jl
+++ b/test/test_power_system_table_data.jl
@@ -88,7 +88,7 @@ end
                     atol = 0.1,
                 ) for i in 1:4
             ] == [true, true, true, true]
-            #@test compare_values_without_uuids(cdmgen.operation_cost, mpgen.operation_cost)
+            #@test PSY.compare_values(cdmgen.operation_cost, mpgen.operation_cost, compare_uuids = false)
         end
     end
 

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -206,3 +206,15 @@ end
         get_name(subcomponent),
     ) !== nothing
 end
+
+@testset "Test deserialization with new UUIDs" begin
+    sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
+    sys2, result =
+        validate_serialization(sys; time_series_read_only = true, assign_new_uuids = true)
+    @test result
+    @test IS.get_uuid(sys) != IS.get_uuid(sys2)
+    for component1 in get_components(Component, sys)
+        component2 = get_component(typeof(component1), sys2, get_name(component1))
+        @test IS.get_uuid(component1) != IS.get_uuid(component2)
+    end
+end

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -328,3 +328,28 @@ end
     @test get_compression_settings(System(100.0, enable_compression = true)) ==
           CompressionSettings(enabled = true)
 end
+
+@testset "Test compare_values" begin
+    sys1 = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
+    sys2 = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys")
+    gen1 = first(get_components(ThermalStandard, sys1))
+    gen2 = first(get_components(ThermalStandard, sys2))
+    @test IS.compare_values(gen1, gen2)
+    @test IS.compare_values(sys1, sys2)
+
+    set_active_power!(gen1, get_active_power(gen1) + 0.1)
+    @test(
+        @test_logs(
+            (:error, r"not match"),
+            match_mode = :any,
+            !IS.compare_values(gen1, gen2),
+        )
+    )
+    @test(
+        @test_logs(
+            (:error, r"not match"),
+            match_mode = :any,
+            !IS.compare_values(sys1, sys2)
+        )
+    )
+end


### PR DESCRIPTION
This PR does two things:
- Fixes NREL-SIIP/PowerSystems.jl#604
- Adds an option to generate new UUIDs during deserialization.

The default behavior for `compare_values` is now to ignore UUIDs by default. We still use this to compare all values during serialization/deserialization.

The use case this addresses is the following:

```
sys1 = PSB.build_system(PSB.PSITestSystems, "test_RTS_GMLC_sys")
sys2 = PSB.build_system(PSB.PSITestSystems, "test_RTS_GMLC_sys")

gen1 = first(get_components(ThermalStandard, sys1))
gen2 = first(get_components(ThermalStandard, sys2))

set_active_power!(gen1, get_active_power(gen1) + 0.1)
PSY.compare_values(gen1, gen2)
┌ Error: values do not match
│   T = ThermalStandard
│   name = :active_power
│   val1 = 0.65
│   val2 = 0.55
└ @ PowerSystems ~/sandboxes/PowerSystems.jl/src/base.jl:1694
```

I decided against implementing `==` for these reasons:

- This is a diagnostic function. As such, it loops over all fields recursively to find all mismatches and then print them out. `==` will return on the first mismatch. `==` will also not print out mismatches.
- In some cases InfrastructureSystems types are immutable structs and we don't want to change the default Julia behavior. There is not a clean division in the type hierarchy between mutable and immutable structs.