### PR TITLE
Fix Powerflow issues

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -97,7 +97,6 @@ for (section, folder) in folders
                           credit = false,
                           documenter = true,
                           postprocess = insert_md,
-                          codefence = "```@example"=>"```",
                           execute = execute)
         subsection = titlecase(replace(split(file, ".")[1], "_" => " "))
         push!(pages[section], ("$subsection" =>  joinpath("$section_folder_name", "$(outputfile).md")))

--- a/docs/src/modeler_guide/power_flow.jl
+++ b/docs/src/modeler_guide/power_flow.jl
@@ -34,8 +34,12 @@ system_data = System(joinpath(DATA_DIR, "matpower/case14.m"))
 # 2. Solves the power flow and updated the devices in the system to the operating condition.
 #    This model will update the values of magnitudes and angles in the system's buses. It
 #    also updates the active and reactive power flows in the branches and devices connected
-#    to PV buses. This utility is useful to initialize systems before serializing or checking
-#    the addition of new devices is still AC feasible.
+#    to PV buses. It also updates the active and reactive power of the injection devices
+#    connected to the Slack bus, and updates only the reactive power of the injection devices
+#    connected to PV buses. If multiple devices are connected to the same bus, the power is 
+#    divided proportional to the base power.
+#    This utility is useful to initialize systems before serializing or checking the
+#    addition of new devices is still AC feasible.
 
 # Solving the power  flow with mode 1:
 

--- a/src/utils/power_flow.jl
+++ b/src/utils/power_flow.jl
@@ -142,19 +142,20 @@ function _write_pf_sol!(sys::System, nl_result)
             Q_gen = result[2 * ix]
             injection = get_components(StaticInjection, sys, x -> get_available(x))
             devices = [d for d in injection if d.bus == bus && !isa(d, ElectricLoad)]
-            generator = devices[1]
-            gen_basepower = get_base_power(generator)
-            set_active_power!(generator, P_gen)
-            set_reactive_power!(generator, Q_gen)
+            sum_basepower = sum(get_base_power.(devices))
+            for d in devices
+                part_factor = get_base_power(d) / sum_basepower
+                set_active_power!(d, P_gen * part_factor)
+                set_reactive_power!(d, Q_gen * part_factor)
+            end
         elseif bus.bustype == BusTypes.PV
             Q_gen = result[2 * ix - 1]
             θ = result[2 * ix]
-            injection_components = get_components(Generator, sys, x -> get_available(x))
-            devices = [d for d in injection_components if d.bus == bus]
-            if length(devices) == 1
-                generator = devices[1]
-                gen_basepower = get_base_power(generator)
-                set_reactive_power!(generator, Q_gen)
+            injection = get_components(StaticInjection, sys, x -> get_available(x))
+            devices = [d for d in injection if d.bus == bus && !isa(d, ElectricLoad)]
+            sum_basepower = sum(get_base_power.(devices))
+            for d in devices
+                set_reactive_power!(d, Q_gen * get_base_power(d) / sum_basepower)
             end
             bus.angle = θ
         elseif bus.bustype == BusTypes.PQ


### PR DESCRIPTION
The following code closes #782 by allowing all StaticInjection to be used in PV Buses. In addition, it allows to split the power based on the `base_power` if multiple devices are connected in the same PV or REF bus.