### PR TITLE
Add examples for show_components

### DIFF
--- a/docs/src/modeler_guide/system.md
+++ b/docs/src/modeler_guide/system.md
@@ -67,6 +67,18 @@ my_thermal_gen = get_component(ThermalStandard, system, "323_CC_1") #hide
 get_active_power_limits(my_thermal_gen)
 ```
 
+You can also view data from all instances of a concrete type in one table with the function `show_components`. It provides a few options:
+
+ 1. View the standard fields by accepting the defaults.
+ 2. Pass a dictionary where the keys are column names and the values are functions that accept a component as a single argument.
+ 3. Pass a vector of symbols that are field names of the type.
+
+```@example show_components
+show_components(system, ThermalStandard)
+show_components(system, ThermalStandard, Dict("has_time_series" => x -> has_time_series(x)))
+show_components(system, ThermalStandard, [:active_power, :reactive_power])
+```
+
 ## [Per-unit conventions and data conversions](@id per_unit)
 
 It is often useful to express power systems data in relative terms using per-unit conventions.

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -216,6 +216,13 @@ Show all components of the given type in a table.
   The Vector option is an array of field names for the `component_type`.
 
 Extra keyword arguments are forwarded to PrettyTables.pretty_table.
+
+# Examples
+```julia
+show_components(sys, ThermalStandard)
+show_components(sys, ThermalStandard, Dict("has_time_series" => x -> has_time_series(x)))
+show_components(sys, ThermalStandard, [:active_power, :reactive_power])
+```
 """
 function show_components(
     sys::System,


### PR DESCRIPTION
There are no functional changes here; just additions to docstrings and the docs.
