### PR TITLE
Add check_components method

### DIFF
--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -27,7 +27,7 @@ load flow case (*.m, *.raw)
 # Keyword arguments
 - `ext::Dict`: Contains user-defined parameters. Should only contain standard types.
 - `runchecks::Bool`: Run available checks on input fields and when add_component! is called.
-  Throws InvalidRange if an error is found.
+  Throws InvalidValue if an error is found.
 - `time_series_in_memory::Bool=false`: Store time series data in memory instead of HDF5.
 - `config_path::String`: specify path to validation config file
 - `pm_data_corrections::Bool=true` : Run the PowerModels data corrections (aka :validate in PowerModels)

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -119,7 +119,7 @@ end
     @test_logs(
         (:error, r"Invalid range"),
         @test_throws(
-            PSY.InvalidRange,
+            PSY.InvalidValue,
             System(100.0, nodes, bad_therm_gen_rating, loads5(nodes); runchecks = true)
         )
     )
@@ -144,7 +144,7 @@ end
         (:error, r"Invalid range"),
         match_mode = :any,
         @test_throws(
-            PSY.InvalidRange,
+            PSY.InvalidValue,
             System(100.0, nodes, bad_therm_gen_ramp_lim, loads5(nodes); runchecks = true)
         )
     )
@@ -249,7 +249,7 @@ end
     @test_logs(
         (:error, r"Invalid range"),
         match_mode = :any,
-        @test_throws IS.InvalidRange add_component!(sys, bus)
+        @test_throws IS.InvalidValue add_component!(sys, bus)
     )
 
     # Allowed with skip_validation.
@@ -277,7 +277,7 @@ end
     @test_logs(
         (:error, r"Invalid range"),
         match_mode = :any,
-        @test_throws(IS.InvalidRange, validate_serialization(sys, runchecks = true)),
+        @test_throws(IS.InvalidValue, validate_serialization(sys, runchecks = true)),
     )
 end
 
@@ -322,12 +322,12 @@ end
     @test_logs(
         (:error, r"Invalid range"),
         match_mode = :any,
-        @test_throws(IS.InvalidRange, check_component(sys, bus)),
+        @test_throws(IS.InvalidValue, check_component(sys, bus)),
     )
     @test_logs(
         (:error, r"Invalid range"),
         match_mode = :any,
-        @test_throws(IS.InvalidRange, check_components(sys)),
+        @test_throws(IS.InvalidValue, check_components(sys)),
     )
 end
 
@@ -341,7 +341,7 @@ end
         (:warn, r"exceeds total capacity capability"),
         match_mode = :any,
         @test_throws(
-            IS.InvalidRange,
+            IS.InvalidValue,
             to_json(sys, "sys.json", force = true, runchecks = true)
         ),
     )


### PR DESCRIPTION
Adds new methods to `check_components` in order to allow PowerSimulations to perform checks on specific component types.

Also updates docstrings for a changed exception in IS.