### PR TITLE
fix dyr parser

### DIFF
--- a/src/parsers/psse_dynamic_data.jl
+++ b/src/parsers/psse_dynamic_data.jl
@@ -244,8 +244,8 @@ function _parse_dyr_components(data::Dict)
     # inv_map contains al the supported structs for inverters
     inv_map = yaml_mapping["inverter_mapping"][1]
 
-    gen_keys = set(keys(gen_map))
-    inv_keys = set(keys(inv_map))
+    gen_keys = Set(keys(gen_map))
+    inv_keys = Set(keys(inv_map))
 
     # dic will contain the dictionary index by bus.
     # Each entry will be a dictionary, with id as keys, that contains the vector of components


### PR DESCRIPTION
The previous version of the .dyr parsing had a problematic bug that made the device loop over all the inverter components while parsing the generator components and causing warnings about non-compatibilities. 

This fixes the issue but it also exposes more the challenge of parsing dyr files into the metamodel we use. I hope that the comments in the code help explain the logic behind it. 

cc. @rodrigomha 