### PR TITLE
Cb/print improvement

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -95,7 +95,7 @@ for (section, folder) in folders
                           outputdir;
                           name = outputfile,
                           credit = false,
-                          documenter = true,
+                          flavor = Literate.DocumenterFlavor(),
                           postprocess = insert_md,
                           execute = execute)
         subsection = titlecase(replace(split(file, ".")[1], "_" => " "))

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ pages = OrderedDict(
             "modeler_guide/type_structure.md",
             "modeler_guide/system.md",
             "modeler_guide/time_series.md",
+            "modeler_guide/enumerated_types.md",
             "modeler_guide/example_dynamic_data.md",
             "modeler_guide/system_dynamic_data.md",
             "modeler_guide/market_bid_cost.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -91,11 +91,13 @@ for (section, folder) in folders
         infile_path = joinpath(pwd(), "docs", "src", inputfile)
         outputfile = string("generated_", replace("$file", ".jl" => ""))
         execute = occursin("EXECUTE = TRUE", uppercase(readline(infile_path))) ? true : false
+        execute && include(infile_path)
         Literate.markdown(infile_path,
                           outputdir;
                           name = outputfile,
                           credit = false,
                           flavor = Literate.DocumenterFlavor(),
+                          documenter = true,
                           postprocess = insert_md,
                           execute = execute)
         subsection = titlecase(replace(split(file, ".")[1], "_" => " "))

--- a/docs/src/modeler_guide/enumerated_types.md
+++ b/docs/src/modeler_guide/enumerated_types.md
@@ -15,20 +15,20 @@ following options:
 
 | EnumName | EnumValue | EIA Fuel Code | Description |
 |----------|-----------|---------------|-------------|
-| COAL | 1 | COL | Anthracite Coal and Bituminous Coal |
-| WASTE_COAL | 2 | WOC | Waste/Other Coal (includes anthracite culm, gob, fine coal, lignite waste, waste coal) |
-| DISTILLATE_FUEL_OIL | 3 | DFO | Distillate Fuel Oil (Diesel, No. 1, No. 2, and No. 4 |
-| WASTE_OIL | 4 | WOO | Waste Oil Kerosene and JetFuel Butane, Propane, |
-| PETROLEUM_COKE | 5 | PC | Petroleum Coke |
-| RESIDUAL_FUEL_OIL | 6 | RFO | Residual Fuel Oil (No. 5, No. 6 Fuel Oils, and Bunker Oil) |
-| NATURAL_GAS | 7 | NG | Natural Gas |
-| OTHER_GAS | 8 | OOG | Other Gas and blast furnace gas |
-| NUCLEAR | 9 | NUC | Nuclear Fission (Uranium, Plutonium, Thorium) |
-| AG_BIPRODUCT | 10 | ORW | Agricultural Crop Byproducts/Straw/Energy Crops |
-| MUNICIPAL_WASTE | 11 |  MLG | Municipal Solid Waste – Biogenic component |
-| WOOD_WASTE | 12 | WWW | Wood Waste Liquids excluding Black Liquor (BLQ) (Includes red liquor, sludge wood, spent sulfite liquor, and other wood-based liquids) |
-| GEOTHERMAL | 13 | GEO | Geothermal |
-| OTHER | 14 | OTH | Other |
+| `COAL` | 1 | COL | Anthracite Coal and Bituminous Coal |
+| `WASTE_COAL` | 2 | WOC | Waste/Other Coal (includes anthracite culm, gob, fine coal, lignite waste, waste coal) |
+| `DISTILLATE_FUEL_OIL` | 3 | DFO | Distillate Fuel Oil (Diesel, No. 1, No. 2, and No. 4) |
+| `WASTE_OIL` | 4 | WOO | Waste Oil Kerosene and JetFuel Butane, Propane |
+| `PETROLEUM_COKE` | 5 | PC | Petroleum Coke |
+| `RESIDUAL_FUEL_OIL` | 6 | RFO | Residual Fuel Oil (No. 5, No. 6 Fuel Oils, and Bunker Oil) |
+| `NATURAL_GAS` | 7 | NG | Natural Gas |
+| `OTHER_GAS` | 8 | OOG | Other Gas and blast furnace gas |
+| `NUCLEAR` | 9 | NUC | Nuclear Fission (Uranium, Plutonium, Thorium) |
+| `AG_BIPRODUCT` | 10 | ORW | Agricultural Crop Byproducts/Straw/Energy Crops |
+| `MUNICIPAL_WASTE` | 11 |  MLG | Municipal Solid Waste – Biogenic component |
+| `WOOD_WASTE` | 12 | WWW | Wood Waste Liquids excluding Black Liquor (BLQ) (Includes red liquor, sludge wood, spent sulfite liquor, and other wood-based liquids) |
+| `GEOTHERMAL` | 13 | GEO | Geothermal |
+| `OTHER` | 14 | OTH | Other |
 
 ## `PrimeMovers`
 
@@ -39,29 +39,29 @@ are intended to reflect the options denoted by
 
 | EnumName | EnumValue | Description |
 |----------|-----------|-------------|
-| BA | 1 | Energy Storage, Battery |
-| BT | 2 | Turbines Used in a Binary Cycle (including those used for geothermal applications) |
-| CA | 3 | Combined-Cycle – Steam Part |
-| CC | 4 | Combined-Cycle - Aggregated Plant *augmentation of EIA |
-| CE | 5 | Energy Storage, Compressed Air |
-| CP | 6 | Energy Storage, Concentrated Solar Power |
-| CS | 7 | Combined-Cycle Single-Shaft Combustion turbine and steam turbine share a single generator |
-| CT | 8 | Combined-Cycle Combustion Turbine Part |
-| ES | 9 | Energy Storage, Other (Specify on Schedule 9, Comments) |
-| FC | 10 | Fuel Cell |
-| FW | 11 | Energy Storage, Flywheel |
-| GT | 12 | Combustion (Gas) Turbine (including jet engine design) |
-| HA | 13 | Hydrokinetic, Axial Flow Turbine |
-| HB | 14 | Hydrokinetic, Wave Buoy |
-| HK | 15 | Hydrokinetic, Other |
-| HY | 16 | Hydraulic Turbine (including turbines associated with delivery of water by pipeline) |
-| IC | 17 | Internal Combustion (diesel, piston, reciprocating) Engine |
-| PS | 18 | Energy Storage, Reversible Hydraulic Turbine (Pumped Storage) |
-| OT | 19 | Other – Specify on SCHEDULE 9. |
-| ST | 20 | Steam Turbine (including nuclear, geothermal and solar steam; does not include combined-cycle turbine) |
-| PV | 21 | Photovoltaic *renaming from EIA PV to PVe to avoid conflict with BusType.PV |
-| WT | 22 | Wind Turbine, Onshore |
-| WS | 23 | Wind Turbine, Offshore |
+| `BA` | 1 | Energy Storage, Battery |
+| `BT` | 2 | Turbines Used in a Binary Cycle (including those used for geothermal applications) |
+| `CA` | 3 | Combined-Cycle – Steam Part |
+| `CC` | 4 | Combined-Cycle - Aggregated Plant *augmentation of EIA |
+| `CE` | 5 | Energy Storage, Compressed Air |
+| `CP` | 6 | Energy Storage, Concentrated Solar Power |
+| `CS` | 7 | Combined-Cycle Single-Shaft Combustion turbine and steam turbine share a single generator |
+| `CT` | 8 | Combined-Cycle Combustion Turbine Part |
+| `ES` | 9 | Energy Storage, Other |
+| `FC` | 10 | Fuel Cell |
+| `FW` | 11 | Energy Storage, Flywheel |
+| `GT` | 12 | Combustion (Gas) Turbine (including jet engine design) |
+| `HA` | 13 | Hydrokinetic, Axial Flow Turbine |
+| `HB` | 14 | Hydrokinetic, Wave Buoy |
+| `HK` | 15 | Hydrokinetic, Other |
+| `HY` | 16 | Hydraulic Turbine (including turbines associated with delivery of water by pipeline) |
+| `IC` | 17 | Internal Combustion (diesel, piston, reciprocating) Engine |
+| `PS` | 18 | Energy Storage, Reversible Hydraulic Turbine (Pumped Storage) |
+| `OT` | 19 | Other |
+| `ST` | 20 | Steam Turbine (including nuclear, geothermal and solar steam; does not include combined-cycle turbine) |
+| `PV` | 21 | Photovoltaic *renaming from EIA PV to PVe to avoid conflict with BusType.PV |
+| `WT` | 22 | Wind Turbine, Onshore |
+| `WS` | 23 | Wind Turbine, Offshore |
 
 ## `BusTypes`
 
@@ -70,31 +70,31 @@ to otherwise categorize buses for modeling activities.
 
 | EnumName | EnumValue | Description |
 |----------|-----------|-------------|
-| ISOLATED | 1 | Disconnected from network |
-| PQ | 2 | Active and reactive power defined (load bus)|
-| PV | 3 | Active power and voltage magnitude defined (generator bus)|
-| REF | 4 | Reference bus (θ = 0)|
-| SLACK | 5 | Slack bus |
+| `ISOLATED` | 1 | Disconnected from network |
+| `PQ` | 2 | Active and reactive power defined (load bus)|
+| `PV` | 3 | Active power and voltage magnitude defined (generator bus)|
+| `REF` | 4 | Reference bus (θ = 0)|
+| `SLACK` | 5 | Slack bus |
 
 ## `AngleUnits`
 
 | EnumName | EnumValue |
 |----------|-----------|
-| DEGREES | 1 |
-| RADIANS | 2 |
+| `DEGREES` | 1 |
+| `RADIANS` | 2 |
 
 ## `LoadModels`
 
 | EnumName | EnumValue | Description |
 |----------|-----------|-------------|
-| ConstantImpedance | 1 | Z |
-| ConstantCurrent | 2 | I |
-| ConstantPower | 3 | P |
+| `ConstantImpedance` | 1 | Z |
+| `ConstantCurrent` | 2 | I |
+| `ConstantPower` | 3 | P |
 
 ## `StateTypes`
 
 | EnumName | EnumValue |
 |----------|-----------|
-| Differential | 1 |
-| Algebraic | 2 |
-| Hybrid | 3 |
+| `Differential` | 1 |
+| `Algebraic` | 2 |
+| `Hybrid` | 3 |

--- a/docs/src/modeler_guide/enumerated_types.md
+++ b/docs/src/modeler_guide/enumerated_types.md
@@ -1,9 +1,10 @@
 
 # Enumerated Types
 
-Some of the fields of `Component` structs are specified with `Enum` types. This is useful
-when the field should specify an option from a pre-defined list. The following are the
-enumerated types contained in `PowerSystems`
+To specify fields representing an option from a pre-defined list, some of the fields of
+`Component` structs are specified with
+[`IS.scoped_enums`](https://nrel-siip.github.io/InfrastructureSystems.jl/stable/InfrastructureSystems/#InfrastructureSystems.@scoped_enum-Tuple{Any,%20Vararg{Any,%20N}%20where%20N}) (e.g.
+`set_fuel!(gen, ThermalFuels.COAL)`). Below are the enumerated types contained in `PowerSystems`.
 
 ## `ThermalFuels`
 
@@ -13,22 +14,22 @@ are intended to reflect the options denoted by the
 EIA Annual Energy Review. Specifically, `ThermalFuels` is an enumerated type with the
 following options:
 
-| EnumName | EnumValue | EIA Fuel Code | Description |
-|----------|-----------|---------------|-------------|
-| `COAL` | 1 | COL | Anthracite Coal and Bituminous Coal |
-| `WASTE_COAL` | 2 | WOC | Waste/Other Coal (includes anthracite culm, gob, fine coal, lignite waste, waste coal) |
-| `DISTILLATE_FUEL_OIL` | 3 | DFO | Distillate Fuel Oil (Diesel, No. 1, No. 2, and No. 4) |
-| `WASTE_OIL` | 4 | WOO | Waste Oil Kerosene and JetFuel Butane, Propane |
-| `PETROLEUM_COKE` | 5 | PC | Petroleum Coke |
-| `RESIDUAL_FUEL_OIL` | 6 | RFO | Residual Fuel Oil (No. 5, No. 6 Fuel Oils, and Bunker Oil) |
-| `NATURAL_GAS` | 7 | NG | Natural Gas |
-| `OTHER_GAS` | 8 | OOG | Other Gas and blast furnace gas |
-| `NUCLEAR` | 9 | NUC | Nuclear Fission (Uranium, Plutonium, Thorium) |
-| `AG_BIPRODUCT` | 10 | ORW | Agricultural Crop Byproducts/Straw/Energy Crops |
-| `MUNICIPAL_WASTE` | 11 |  MLG | Municipal Solid Waste – Biogenic component |
-| `WOOD_WASTE` | 12 | WWW | Wood Waste Liquids excluding Black Liquor (BLQ) (Includes red liquor, sludge wood, spent sulfite liquor, and other wood-based liquids) |
-| `GEOTHERMAL` | 13 | GEO | Geothermal |
-| `OTHER` | 14 | OTH | Other |
+| EnumName | EIA Fuel Code | Description |
+|----------|---------------|-------------|
+| `COAL` | COL | Anthracite Coal and Bituminous Coal |
+| `WASTE_COAL` | WOC | Waste/Other Coal (includes anthracite culm, gob, fine coal, lignite waste, waste coal) |
+| `DISTILLATE_FUEL_OIL` | DFO | Distillate Fuel Oil (Diesel, No. 1, No. 2, and No. 4) |
+| `WASTE_OIL` | WOO | Waste Oil Kerosene and JetFuel Butane, Propane |
+| `PETROLEUM_COKE` | PC | Petroleum Coke |
+| `RESIDUAL_FUEL_OIL` | RFO | Residual Fuel Oil (No. 5, No. 6 Fuel Oils, and Bunker Oil) |
+| `NATURAL_GAS` | NG | Natural Gas |
+| `OTHER_GAS` | OOG | Other Gas and blast furnace gas |
+| `NUCLEAR` | NUC | Nuclear Fission (Uranium, Plutonium, Thorium) |
+| `AG_BIPRODUCT` | ORW | Agricultural Crop Byproducts/Straw/Energy Crops |
+| `MUNICIPAL_WASTE` |  MLG | Municipal Solid Waste – Biogenic component |
+| `WOOD_WASTE` | WWW | Wood Waste Liquids excluding Black Liquor (BLQ) (Includes red liquor, sludge wood, spent sulfite liquor, and other wood-based liquids) |
+| `GEOTHERMAL` | GEO | Geothermal |
+| `OTHER` | OTH | Other |
 
 ## `PrimeMovers`
 
@@ -37,64 +38,64 @@ are intended to reflect the options denoted by
 [EIA form 923](https://www.eia.gov/survey/form/eia_923/instructions.pdf). Specifically,
 `PrimeMovers` is an enumerated type with the following options:
 
-| EnumName | EnumValue | Description |
-|----------|-----------|-------------|
-| `BA` | 1 | Energy Storage, Battery |
-| `BT` | 2 | Turbines Used in a Binary Cycle (including those used for geothermal applications) |
-| `CA` | 3 | Combined-Cycle – Steam Part |
-| `CC` | 4 | Combined-Cycle - Aggregated Plant *augmentation of EIA |
-| `CE` | 5 | Energy Storage, Compressed Air |
-| `CP` | 6 | Energy Storage, Concentrated Solar Power |
-| `CS` | 7 | Combined-Cycle Single-Shaft Combustion turbine and steam turbine share a single generator |
-| `CT` | 8 | Combined-Cycle Combustion Turbine Part |
-| `ES` | 9 | Energy Storage, Other |
-| `FC` | 10 | Fuel Cell |
-| `FW` | 11 | Energy Storage, Flywheel |
-| `GT` | 12 | Combustion (Gas) Turbine (including jet engine design) |
-| `HA` | 13 | Hydrokinetic, Axial Flow Turbine |
-| `HB` | 14 | Hydrokinetic, Wave Buoy |
-| `HK` | 15 | Hydrokinetic, Other |
-| `HY` | 16 | Hydraulic Turbine (including turbines associated with delivery of water by pipeline) |
-| `IC` | 17 | Internal Combustion (diesel, piston, reciprocating) Engine |
-| `PS` | 18 | Energy Storage, Reversible Hydraulic Turbine (Pumped Storage) |
-| `OT` | 19 | Other |
-| `ST` | 20 | Steam Turbine (including nuclear, geothermal and solar steam; does not include combined-cycle turbine) |
-| `PV` | 21 | Photovoltaic *renaming from EIA PV to PVe to avoid conflict with BusType.PV |
-| `WT` | 22 | Wind Turbine, Onshore |
-| `WS` | 23 | Wind Turbine, Offshore |
+| EnumName | Description |
+|----------|-------------|
+| `BA` | Energy Storage, Battery |
+| `BT` | Turbines Used in a Binary Cycle (including those used for geothermal applications) |
+| `CA` | Combined-Cycle – Steam Part |
+| `CC` | Combined-Cycle - Aggregated Plant *augmentation of EIA |
+| `CE` | Energy Storage, Compressed Air |
+| `CP` | Energy Storage, Concentrated Solar Power |
+| `CS` | Combined-Cycle Single-Shaft Combustion turbine and steam turbine share a single generator |
+| `CT` | Combined-Cycle Combustion Turbine Part |
+| `ES` | Energy Storage, Other |
+| `FC` | Fuel Cell |
+| `FW` | Energy Storage, Flywheel |
+| `GT` | Combustion (Gas) Turbine (including jet engine design) |
+| `HA` | Hydrokinetic, Axial Flow Turbine |
+| `HB` | Hydrokinetic, Wave Buoy |
+| `HK` | Hydrokinetic, Other |
+| `HY` | Hydraulic Turbine (including turbines associated with delivery of water by pipeline) |
+| `IC` | Internal Combustion (diesel, piston, reciprocating) Engine |
+| `PS` | Energy Storage, Reversible Hydraulic Turbine (Pumped Storage) |
+| `OT` | Other |
+| `ST` | Steam Turbine (including nuclear, geothermal and solar steam; does not include combined-cycle turbine) |
+| `PV` | Photovoltaic *renaming from EIA PV to PVe to avoid conflict with BusType.PV |
+| `WT` | Wind Turbine, Onshore |
+| `WS` | Wind Turbine, Offshore |
 
 ## `BusTypes`
 
 `BusTypes` is used to denote which quantities are specified for load flow calculations and
 to otherwise categorize buses for modeling activities.
 
-| EnumName | EnumValue | Description |
-|----------|-----------|-------------|
-| `ISOLATED` | 1 | Disconnected from network |
-| `PQ` | 2 | Active and reactive power defined (load bus)|
-| `PV` | 3 | Active power and voltage magnitude defined (generator bus)|
-| `REF` | 4 | Reference bus (θ = 0)|
-| `SLACK` | 5 | Slack bus |
+| EnumName | Description |
+|----------|-------------|
+| `ISOLATED` | Disconnected from network |
+| `PQ` | Active and reactive power defined (load bus)|
+| `PV` | Active power and voltage magnitude defined (generator bus)|
+| `REF` | Reference bus (θ = 0)|
+| `SLACK` | Slack bus |
 
 ## `AngleUnits`
 
-| EnumName | EnumValue |
-|----------|-----------|
-| `DEGREES` | 1 |
-| `RADIANS` | 2 |
+| EnumName |
+|----------|
+| `DEGREES` |
+| `RADIANS` |
 
 ## `LoadModels`
 
-| EnumName | EnumValue | Description |
-|----------|-----------|-------------|
-| `ConstantImpedance` | 1 | Z |
-| `ConstantCurrent` | 2 | I |
-| `ConstantPower` | 3 | P |
+| EnumName | Description |
+|----------|-------------|
+| `ConstantImpedance` | Z |
+| `ConstantCurrent` | I |
+| `ConstantPower` | P |
 
 ## `StateTypes`
 
-| EnumName | EnumValue |
-|----------|-----------|
-| `Differential` | 1 |
-| `Algebraic` | 2 |
-| `Hybrid` | 3 |
+| EnumName |
+|----------|
+| `Differential` |
+| `Algebraic` |
+| `Hybrid` |

--- a/docs/src/modeler_guide/enumerated_types.md
+++ b/docs/src/modeler_guide/enumerated_types.md
@@ -1,0 +1,100 @@
+
+# Enumerated Types
+
+Some of the fields of `Component` structs are specified with `Enum` types. This is useful
+when the field should specify an option from a pre-defined list. The following are the
+enumerated types contained in `PowerSystems`
+
+## `ThermalFuels`
+
+Each `ThermalGen` generator struct contains a field for `fuel::ThermalFuels` where `ThermalFuels`
+are intended to reflect the options denoted by the
+[Aggregated Fuel Codes](https://www.eia.gov/survey/form/eia_923/instructions.pdf) from the
+EIA Annual Energy Review. Specifically, `ThermalFuels` is an enumerated type with the
+following options:
+
+| EnumName | EnumValue | EIA Fuel Code | Description |
+|----------|-----------|---------------|-------------|
+| COAL | 1 | COL | Anthracite Coal and Bituminous Coal |
+| WASTE_COAL | 2 | WOC | Waste/Other Coal (includes anthracite culm, gob, fine coal, lignite waste, waste coal) |
+| DISTILLATE_FUEL_OIL | 3 | DFO | Distillate Fuel Oil (Diesel, No. 1, No. 2, and No. 4 |
+| WASTE_OIL | 4 | WOO | Waste Oil Kerosene and JetFuel Butane, Propane, |
+| PETROLEUM_COKE | 5 | PC | Petroleum Coke |
+| RESIDUAL_FUEL_OIL | 6 | RFO | Residual Fuel Oil (No. 5, No. 6 Fuel Oils, and Bunker Oil) |
+| NATURAL_GAS | 7 | NG | Natural Gas |
+| OTHER_GAS | 8 | OOG | Other Gas and blast furnace gas |
+| NUCLEAR | 9 | NUC | Nuclear Fission (Uranium, Plutonium, Thorium) |
+| AG_BIPRODUCT | 10 | ORW | Agricultural Crop Byproducts/Straw/Energy Crops |
+| MUNICIPAL_WASTE | 11 |  MLG | Municipal Solid Waste – Biogenic component |
+| WOOD_WASTE | 12 | WWW | Wood Waste Liquids excluding Black Liquor (BLQ) (Includes red liquor, sludge wood, spent sulfite liquor, and other wood-based liquids) |
+| GEOTHERMAL | 13 | GEO | Geothermal |
+| OTHER | 14 | OTH | Other |
+
+## `PrimeMovers`
+
+Each generator struct contains a field for `prime_mover::PrimeMovers` where `PrimeMovers`
+are intended to reflect the options denoted by
+[EIA form 923](https://www.eia.gov/survey/form/eia_923/instructions.pdf). Specifically,
+`PrimeMovers` is an enumerated type with the following options:
+
+| EnumName | EnumValue | Description |
+|----------|-----------|-------------|
+| BA | 1 | Energy Storage, Battery |
+| BT | 2 | Turbines Used in a Binary Cycle (including those used for geothermal applications) |
+| CA | 3 | Combined-Cycle – Steam Part |
+| CC | 4 | Combined-Cycle - Aggregated Plant *augmentation of EIA |
+| CE | 5 | Energy Storage, Compressed Air |
+| CP | 6 | Energy Storage, Concentrated Solar Power |
+| CS | 7 | Combined-Cycle Single-Shaft Combustion turbine and steam turbine share a single generator |
+| CT | 8 | Combined-Cycle Combustion Turbine Part |
+| ES | 9 | Energy Storage, Other (Specify on Schedule 9, Comments) |
+| FC | 10 | Fuel Cell |
+| FW | 11 | Energy Storage, Flywheel |
+| GT | 12 | Combustion (Gas) Turbine (including jet engine design) |
+| HA | 13 | Hydrokinetic, Axial Flow Turbine |
+| HB | 14 | Hydrokinetic, Wave Buoy |
+| HK | 15 | Hydrokinetic, Other |
+| HY | 16 | Hydraulic Turbine (including turbines associated with delivery of water by pipeline) |
+| IC | 17 | Internal Combustion (diesel, piston, reciprocating) Engine |
+| PS | 18 | Energy Storage, Reversible Hydraulic Turbine (Pumped Storage) |
+| OT | 19 | Other – Specify on SCHEDULE 9. |
+| ST | 20 | Steam Turbine (including nuclear, geothermal and solar steam; does not include combined-cycle turbine) |
+| PV | 21 | Photovoltaic *renaming from EIA PV to PVe to avoid conflict with BusType.PV |
+| WT | 22 | Wind Turbine, Onshore |
+| WS | 23 | Wind Turbine, Offshore |
+
+## `BusTypes`
+
+`BusTypes` is used to denote which quantities are specified for load flow calculations and
+to otherwise categorize buses for modeling activities.
+
+| EnumName | EnumValue | Description |
+|----------|-----------|-------------|
+| ISOLATED | 1 | Disconnected from network |
+| PQ | 2 | Active and reactive power defined (load bus)|
+| PV | 3 | Active power and voltage magnitude defined (generator bus)|
+| REF | 4 | Reference bus (θ = 0)|
+| SLACK | 5 | Slack bus |
+
+## `AngleUnits`
+
+| EnumName | EnumValue |
+|----------|-----------|
+| DEGREES | 1 |
+| RADIANS | 2 |
+
+## `LoadModels`
+
+| EnumName | EnumValue | Description |
+|----------|-----------|-------------|
+| ConstantImpedance | 1 | Z |
+| ConstantCurrent | 2 | I |
+| ConstantPower | 3 | P |
+
+## `StateTypes`
+
+| EnumName | EnumValue |
+|----------|-----------|
+| Differential | 1 |
+| Algebraic | 2 |
+| Hybrid | 3 |

--- a/docs/src/modeler_guide/parsing.jl
+++ b/docs/src/modeler_guide/parsing.jl
@@ -93,7 +93,7 @@
 #
 # ```@example raw_dyr_system
 # using PowerSystems
-# data_dir = "../../../data" # hide
+# data_dir = "../../../data"
 # RAW_dir = joinpath(data_dir, "PSSE_test/ThreeBusNetwork.raw")
 # DYR_dir = joinpath(data_dir, "PSSE_test/TestGENCLS.dyr")
 # dyn_system = System(RAW_dir, DYR_dir, runchecks = false)
@@ -273,61 +273,63 @@
 # `PowerSystemeTableData` parser defined by `src/descriptors/power_system_inputs.json`:
 #
 
-using PowerSystems # hide
-function create_md() # hide
-    descriptor = PowerSystems._read_config_file(joinpath( # hide
-        dirname(pathof(PowerSystems)), # hide
-        "descriptors", # hide
-        "power_system_inputs.json", # hide
-    )) # hide
-    columns = [ # hide
-        "name", # hide
-        "description", # hide
-        "unit", # hide
-        "unit_system", # hide
-        "base_reference", # hide
-        "default_value", # hide
-        "value_options", # hide
-        "value_range", # hide
-    ] # hide
-    header = "| " * join(columns, " | ") * " |\n" * repeat("|----", length(columns)) * "|\n" # hide
-    s = "" # hide
-    for (cat, items) in descriptor # hide
-        csv = "" # hide
-        for name in PowerSystems.INPUT_CATEGORY_NAMES # hide
-            if name[2] == cat # hide
-                csv = name[1] # hide
-                break # hide
-            end # hide
-        end # hide
-        csv == "" && continue # hide
-        s = string(s, "### $csv.csv:\n\n") # hide
-        s = string(s, header) # hide
-        for item in items # hide
-            extra_cols = setdiff(keys(item), columns) # hide
-            if !isempty(extra_cols) # hide
-                throw(@error "config file fields not included in header" extra_cols) # hide
-            end # hide
-            row = [] # hide
-            for col in columns # hide
-                val = string(get(item, col, " ")) # hide
-                if col == "default_value" && val == " " # hide
-                    val = "*REQUIRED*" # hide
-                end # hide
-                push!(row, val) # hide
-            end # hide
-            s = string(s, "|" * join(row, "|") * "|\n") # hide
-        end # hide
-        s = string(s, "\n") # hide
-    end # hide
-    s = replace(s, r"[_$]" => s"\\\g<0>"); # hide
-    return s # hide
-end # hide
-txt = create_md(); # hide
-fname = joinpath(dirname(dirname(pathof(PowerSystems))), "docs", "src", "modeler_guide", "generated_inputs_tables.md") # hide
-open(fname, "w") do io # hide
-      write(io, txt) # hide
-end # hide
-println(" "); # hide
+# ```@raw
+# using PowerSystems
+# function create_md()
+#     descriptor = PowerSystems._read_config_file(joinpath(
+#         dirname(pathof(PowerSystems)),
+#         "descriptors",
+#         "power_system_inputs.json",
+#     ))
+#     columns = [
+#         "name",
+#         "description",
+#         "unit",
+#         "unit_system",
+#         "base_reference",
+#         "default_value",
+#         "value_options",
+#         "value_range",
+#     ]
+#     header = "| " * join(columns, " | ") * " |\n" * repeat("|----", length(columns)) * "|\n"
+#     s = ""
+#     for (cat, items) in descriptor
+#         csv = ""
+#         for name in PowerSystems.INPUT_CATEGORY_NAMES
+#             if name[2] == cat
+#                 csv = name[1]
+#                 break
+#             end
+#         end
+#         csv == "" && continue
+#         s = string(s, "### $csv.csv:\n\n")
+#         s = string(s, header)
+#         for item in items
+#             extra_cols = setdiff(keys(item), columns)
+#             if !isempty(extra_cols)
+#                 throw(@error "config file fields not included in header" extra_cols)
+#             end
+#             row = []
+#             for col in columns
+#                 val = string(get(item, col, " "))
+#                 if col == "default_value" && val == " "
+#                     val = "*REQUIRED*"
+#                 end
+#                 push!(row, val)
+#             end
+#             s = string(s, "|" * join(row, "|") * "|\n")
+#         end
+#         s = string(s, "\n")
+#     end
+#     s = replace(s, r"[_$]" => s"\\\g<0>");
+#     return s
+# end
+# txt = create_md();
+# fname = joinpath(dirname(dirname(pathof(PowerSystems))), "docs", "src", "modeler_guide", "generated_inputs_tables.md")
+# open(fname, "w") do io
+#       write(io, txt)
+# end
+# println(" ");
+# ```
 
 # APPEND_MARKDOWN("docs/src/modeler_guide/generated_inputs_tables.md")

--- a/docs/src/modeler_guide/parsing.jl
+++ b/docs/src/modeler_guide/parsing.jl
@@ -1,5 +1,3 @@
-#src execute = true
-
 # # [Parsing Data](@id parsing)
 #
 # `PowerSystems.jl` supports the creation of a `System` from a variety of common data formats:
@@ -257,79 +255,75 @@
 # per-unit conversion by dividing the value by the entry in `My Column`. System base
 # per-unit conversions always divide the value by the system `base_power` value
 # instantiated when constructing a `System`.
-#
+
 # ##### [Unit conversion](@id csv_units)
-#
+
 # PowerSystems provides a limited set of unit conversions. For example, if
 # `power_system_inputs.json` indicates that a value's unit is degrees but
 # your values are in radians then you can set `unit: radian` in
 # your YAML file. Other valid `unit` entries include `GW`, `GWh`, `MW`, `MWh`, `kW`,
 # and `kWh`.
-#
 
 # ## [`PowerSystemTableData` Accepted CSV Columns](@id tabledata_input_config)
-#
+
 # The following tables describe default CSV column definitions accepted by the
 # `PowerSystemeTableData` parser defined by `src/descriptors/power_system_inputs.json`:
-#
 
-# ```@raw
-# using PowerSystems
-# function create_md()
-#     descriptor = PowerSystems._read_config_file(joinpath(
-#         dirname(pathof(PowerSystems)),
-#         "descriptors",
-#         "power_system_inputs.json",
-#     ))
-#     columns = [
-#         "name",
-#         "description",
-#         "unit",
-#         "unit_system",
-#         "base_reference",
-#         "default_value",
-#         "value_options",
-#         "value_range",
-#     ]
-#     header = "| " * join(columns, " | ") * " |\n" * repeat("|----", length(columns)) * "|\n"
-#     s = ""
-#     for (cat, items) in descriptor
-#         csv = ""
-#         for name in PowerSystems.INPUT_CATEGORY_NAMES
-#             if name[2] == cat
-#                 csv = name[1]
-#                 break
-#             end
-#         end
-#         csv == "" && continue
-#         s = string(s, "### $csv.csv:\n\n")
-#         s = string(s, header)
-#         for item in items
-#             extra_cols = setdiff(keys(item), columns)
-#             if !isempty(extra_cols)
-#                 throw(@error "config file fields not included in header" extra_cols)
-#             end
-#             row = []
-#             for col in columns
-#                 val = string(get(item, col, " "))
-#                 if col == "default_value" && val == " "
-#                     val = "*REQUIRED*"
-#                 end
-#                 push!(row, val)
-#             end
-#             s = string(s, "|" * join(row, "|") * "|\n")
-#         end
-#         s = string(s, "\n")
-#     end
-#     s = replace(s, r"[_$]" => s"\\\g<0>");
-#     return s
-# end
-# txt = create_md();
-# fname = joinpath(dirname(dirname(pathof(PowerSystems))), "docs", "src", "modeler_guide", "generated_inputs_tables.md")
-# open(fname, "w") do io
-#       write(io, txt)
-# end
-# println(" ");
-# ```
+using PowerSystems #hide
+function create_md() #hide
+    descriptor = PowerSystems._read_config_file(joinpath( #hide
+        dirname(pathof(PowerSystems)), #hide
+        "descriptors", #hide
+        "power_system_inputs.json", #hide
+    )) #hide
+    columns = [ #hide
+        "name", #hide
+        "description", #hide
+        "unit", #hide
+        "unit_system", #hide
+        "base_reference", #hide
+        "default_value", #hide
+        "value_options", #hide
+        "value_range", #hide
+    ] #hide
+    header = "| " * join(columns, " | ") * " |\n" * repeat("|----", length(columns)) * "|\n" #hide
+    s = "" #hide
+    for (cat, items) in descriptor #hide
+        csv = "" #hide
+        for name in PowerSystems.INPUT_CATEGORY_NAMES #hide
+            if name[2] == cat #hide
+                csv = name[1] #hide
+                break #hide
+            end #hide
+        end #hide
+        csv == "" && continue #hide
+        s = string(s, "### $csv.csv:\n\n") #hide
+        s = string(s, header) #hide
+        for item in items #hide
+            extra_cols = setdiff(keys(item), columns) #hide
+            if !isempty(extra_cols) #hide
+                throw(@error "config file fields not included in header" extra_cols) #hide
+            end #hide
+            row = [] #hide
+            for col in columns #hide
+                val = string(get(item, col, " ")) #hide
+                if col == "default_value" && val == " " #hide
+                    val = "*REQUIRED*" #hide
+                end #hide
+                push!(row, val) #hide
+            end #hide
+            s = string(s, "|" * join(row, "|") * "|\n") #hide
+        end #hide
+        s = string(s, "\n") #hide
+    end #hide
+    s = replace(s, r"[_$]" => s"\\\g<0>"); #hide
+    return s #hide
+end #hide
+txt = create_md(); #hide
+fname = joinpath(dirname(dirname(pathof(PowerSystems))), "docs", "src", "modeler_guide", "generated_inputs_tables.md") #hide
+open(fname, "w") do io #hide
+      write(io, txt) #hide
+end #hide
+nothing #hide
 
 # APPEND_MARKDOWN("docs/src/modeler_guide/generated_inputs_tables.md")

--- a/docs/src/modeler_guide/parsing.jl
+++ b/docs/src/modeler_guide/parsing.jl
@@ -1,3 +1,4 @@
+#src EXECUTE = TRUE
 # # [Parsing Data](@id parsing)
 #
 # `PowerSystems.jl` supports the creation of a `System` from a variety of common data formats:
@@ -269,61 +270,61 @@
 # The following tables describe default CSV column definitions accepted by the
 # `PowerSystemeTableData` parser defined by `src/descriptors/power_system_inputs.json`:
 
-using PowerSystems #hide
-function create_md() #hide
-    descriptor = PowerSystems._read_config_file(joinpath( #hide
-        dirname(pathof(PowerSystems)), #hide
-        "descriptors", #hide
-        "power_system_inputs.json", #hide
-    )) #hide
-    columns = [ #hide
-        "name", #hide
-        "description", #hide
-        "unit", #hide
-        "unit_system", #hide
-        "base_reference", #hide
-        "default_value", #hide
-        "value_options", #hide
-        "value_range", #hide
-    ] #hide
-    header = "| " * join(columns, " | ") * " |\n" * repeat("|----", length(columns)) * "|\n" #hide
-    s = "" #hide
-    for (cat, items) in descriptor #hide
-        csv = "" #hide
-        for name in PowerSystems.INPUT_CATEGORY_NAMES #hide
-            if name[2] == cat #hide
-                csv = name[1] #hide
-                break #hide
-            end #hide
-        end #hide
-        csv == "" && continue #hide
-        s = string(s, "### $csv.csv:\n\n") #hide
-        s = string(s, header) #hide
-        for item in items #hide
-            extra_cols = setdiff(keys(item), columns) #hide
-            if !isempty(extra_cols) #hide
-                throw(@error "config file fields not included in header" extra_cols) #hide
-            end #hide
-            row = [] #hide
-            for col in columns #hide
-                val = string(get(item, col, " ")) #hide
-                if col == "default_value" && val == " " #hide
-                    val = "*REQUIRED*" #hide
-                end #hide
-                push!(row, val) #hide
-            end #hide
-            s = string(s, "|" * join(row, "|") * "|\n") #hide
-        end #hide
-        s = string(s, "\n") #hide
-    end #hide
-    s = replace(s, r"[_$]" => s"\\\g<0>"); #hide
-    return s #hide
-end #hide
-txt = create_md(); #hide
-fname = joinpath(dirname(dirname(pathof(PowerSystems))), "docs", "src", "modeler_guide", "generated_inputs_tables.md") #hide
-open(fname, "w") do io #hide
-      write(io, txt) #hide
-end #hide
-nothing #hide
+using PowerSystems #src
+function create_md() #src
+    descriptor = PowerSystems._read_config_file(joinpath( #src
+        dirname(pathof(PowerSystems)), #src
+        "descriptors", #src
+        "power_system_inputs.json", #src
+    )) #src
+    columns = [ #src
+        "name", #src
+        "description", #src
+        "unit", #src
+        "unit_system", #src
+        "base_reference", #src
+        "default_value", #src
+        "value_options", #src
+        "value_range", #src
+    ] #src
+    header = "| " * join(columns, " | ") * " |\n" * repeat("|----", length(columns)) * "|\n" #src
+    s = "" #src
+    for (cat, items) in descriptor #src
+        csv = "" #src
+        for name in PowerSystems.INPUT_CATEGORY_NAMES #src
+            if name[2] == cat #src
+                csv = name[1] #src
+                break #src
+            end #src
+        end #src
+        csv == "" && continue #src
+        s = string(s, "### $csv.csv:\n\n") #src
+        s = string(s, header) #src
+        for item in items #src
+            extra_cols = setdiff(keys(item), columns) #src
+            if !isempty(extra_cols) #src
+                throw(@error "config file fields not included in header" extra_cols) #src
+            end #src
+            row = [] #src
+            for col in columns #src
+                val = string(get(item, col, " ")) #src
+                if col == "default_value" && val == " " #src
+                    val = "*REQUIRED*" #src
+                end #src
+                push!(row, val) #src
+            end #src
+            s = string(s, "|" * join(row, "|") * "|\n") #src
+        end #src
+        s = string(s, "\n") #src
+    end #src
+    s = replace(s, r"[_$]" => s"\\\g<0>"); #src
+    return s #src
+end #src
+txt = create_md(); #src
+fname = joinpath(dirname(dirname(pathof(PowerSystems))), "docs", "src", "modeler_guide", "generated_inputs_tables.md") #src
+open(fname, "w") do io #src
+      write(io, txt) #src
+end #src
+nothing #src
 
 # APPEND_MARKDOWN("docs/src/modeler_guide/generated_inputs_tables.md")

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -199,7 +199,6 @@ export PTDF
 export Ybus
 export LODF
 export Adjacency
-export GeneratorCostModels
 export AngleUnits
 export BusTypes
 export LoadModels

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -20,11 +20,11 @@ function Base.show(io::IO, ::MIME"text/html", sys::System)
     show_system_table(io, sys, backend = :html)
 
     if IS.get_num_components(sys.data.components) > 0
-        show_components_table(io, sys, backend = :html, tf = PrettyTables.tf_html_dark)
+        show_components_table(io, sys, backend = :html, tf = PrettyTables.tf_html_simple)
     end
 
     println(io)
-    IS.show_time_series_data(io, sys.data, backend = :html, tf = PrettyTables.tf_html_dark)
+    IS.show_time_series_data(io, sys.data, backend = :html, tf = PrettyTables.tf_html_simple)
     return
 end
 

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -20,11 +20,11 @@ function Base.show(io::IO, ::MIME"text/html", sys::System)
     show_system_table(io, sys, backend = :html)
 
     if IS.get_num_components(sys.data.components) > 0
-        show_components_table(io, sys, backend = :html)
+        show_components_table(io, sys, backend = :html, tf = PrettyTables.tf_html_dark)
     end
 
     println(io)
-    IS.show_time_series_data(io, sys.data, backend = :html)
+    IS.show_time_series_data(io, sys.data, backend = :html, tf = PrettyTables.tf_html_dark)
     return
 end
 

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -24,7 +24,12 @@ function Base.show(io::IO, ::MIME"text/html", sys::System)
     end
 
     println(io)
-    IS.show_time_series_data(io, sys.data, backend = :html, tf = PrettyTables.tf_html_simple)
+    IS.show_time_series_data(
+        io,
+        sys.data,
+        backend = :html,
+        tf = PrettyTables.tf_html_simple,
+    )
     return
 end
 


### PR DESCRIPTION
addressing #817 and #833

1. I changed the pretty tables html format to `tf_html_dark`. this looks better in my notebook (you can see the header), but I don't know how to test the docs page.
2. I changed the code block in the parsing documentation that renders all the tabular input option data tables so that it's hidden with an `@raw` block. Again, I'm unclear on how to test.
