### PR TITLE
Change order of VirtualInertia states

### DIFF
--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -10480,8 +10480,8 @@
         {
           "name": "states",
           "exclude_setter": true,
-          "comment": "The states of the VirtualInertia model are:\n\tω_oc: Speed of the rotating reference frame of the virtual synchronous generator model,\n\tθ_oc: Phase angle displacement of the virtual synchronous generator model",
-          "internal_default": "[:ω_oc, :θ_oc]",
+          "comment": "The states of the VirtualInertia model are:\n\tθ_oc: Phase angle displacement of the virtual synchronous generator model\n\tω_oc: Speed of the rotating reference frame of the virtual synchronous generator model",
+          "internal_default": "[:θ_oc, :ω_oc]",
           "data_type": "Vector{Symbol}"
         },
         {

--- a/src/models/generated/VirtualInertia.jl
+++ b/src/models/generated/VirtualInertia.jl
@@ -21,8 +21,8 @@ Parameters of a Virtual Inertia with SRF using VSM for active power controller
 - `P_ref::Float64`: Reference Power Set-point, validation range: `(0, nothing)`
 - `ext::Dict{String, Any}`
 - `states::Vector{Symbol}`: The states of the VirtualInertia model are:
-	ω_oc: Speed of the rotating reference frame of the virtual synchronous generator model,
 	θ_oc: Phase angle displacement of the virtual synchronous generator model
+	ω_oc: Speed of the rotating reference frame of the virtual synchronous generator model
 - `n_states::Int`: VirtualInertia has two states
 """
 mutable struct VirtualInertia <: ActivePowerControl
@@ -36,18 +36,18 @@ mutable struct VirtualInertia <: ActivePowerControl
     P_ref::Float64
     ext::Dict{String, Any}
     "The states of the VirtualInertia model are:
-	ω_oc: Speed of the rotating reference frame of the virtual synchronous generator model,
-	θ_oc: Phase angle displacement of the virtual synchronous generator model"
+	θ_oc: Phase angle displacement of the virtual synchronous generator model
+	ω_oc: Speed of the rotating reference frame of the virtual synchronous generator model"
     states::Vector{Symbol}
     "VirtualInertia has two states"
     n_states::Int
 end
 
 function VirtualInertia(Ta, kd, kω, P_ref=1.0, ext=Dict{String, Any}(), )
-    VirtualInertia(Ta, kd, kω, P_ref, ext, [:ω_oc, :θ_oc], 2, )
+    VirtualInertia(Ta, kd, kω, P_ref, ext, [:θ_oc, :ω_oc], 2, )
 end
 
-function VirtualInertia(; Ta, kd, kω, P_ref=1.0, ext=Dict{String, Any}(), states=[:ω_oc, :θ_oc], n_states=2, )
+function VirtualInertia(; Ta, kd, kω, P_ref=1.0, ext=Dict{String, Any}(), states=[:θ_oc, :ω_oc], n_states=2, )
     VirtualInertia(Ta, kd, kω, P_ref, ext, states, n_states, )
 end
 


### PR DESCRIPTION
The change flips two states for the purpose of standardizing that order in PSID.

This should break PSID, that is fixed In another PR.