### PR TITLE
Improve handling of set_name! on components

### DIFF
--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -221,6 +221,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -267,6 +268,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -312,6 +314,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "comment": "the name of the bus",
           "data_type": "String"
         },
@@ -420,6 +423,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -529,6 +533,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -646,6 +651,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -770,6 +776,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -885,6 +892,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -990,6 +998,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -1074,6 +1083,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -1158,6 +1168,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -1260,6 +1271,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -1315,6 +1327,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -1411,6 +1424,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -1609,6 +1623,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -1756,6 +1771,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -2028,6 +2044,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -2148,6 +2165,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -2256,6 +2274,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -2423,6 +2442,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -2616,6 +2636,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -2778,6 +2799,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -2948,6 +2970,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -3000,6 +3023,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -3053,6 +3077,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -3109,6 +3134,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -3158,6 +3184,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -3212,6 +3239,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -3265,6 +3293,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -3337,6 +3366,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -11542,6 +11572,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {
@@ -11640,6 +11671,7 @@
         {
           "null_value": "init",
           "name": "name",
+          "exclude_setter": true,
           "data_type": "String"
         },
         {

--- a/src/models/HybridSystem.jl
+++ b/src/models/HybridSystem.jl
@@ -182,7 +182,6 @@ InfrastructureSystems.get_time_series_container(value::HybridSystem) =
 """Get [`HybridSystem`](@ref) `internal`."""
 get_internal(value::HybridSystem) = value.internal
 
-InfrastructureSystems.set_name!(value::HybridSystem, val) = value.name = val
 """Set [`HybridSystem`](@ref) `available`."""
 set_available!(value::HybridSystem, val) = value.available = val
 """Get [`HybridSystem`](@ref) `status`."""

--- a/src/models/dynamic_branch.jl
+++ b/src/models/dynamic_branch.jl
@@ -74,7 +74,6 @@ get_services(value::DynamicBranch) = get_services(value.branch)
 """Get DynamicBranch ext."""
 get_ext(value::DynamicBranch) = get_ext(value.branch)
 
-set_name!(value::DynamicBranch, val::String) = set_name!(value.branch, val)
 """Set DynamicBranch available."""
 set_available!(value::DynamicBranch, val::Bool) = set_available!(value.branch, val)
 """Set DynamicBranch active_power_flow."""

--- a/src/models/generated/AGC.jl
+++ b/src/models/generated/AGC.jl
@@ -99,8 +99,6 @@ get_ext(value::AGC) = value.ext
 """Get [`AGC`](@ref) `internal`."""
 get_internal(value::AGC) = value.internal
 
-"""Set [`AGC`](@ref) `name`."""
-set_name!(value::AGC, val) = value.name = val
 """Set [`AGC`](@ref) `available`."""
 set_available!(value::AGC, val) = value.available = val
 """Set [`AGC`](@ref) `bias`."""

--- a/src/models/generated/Area.jl
+++ b/src/models/generated/Area.jl
@@ -64,8 +64,6 @@ get_time_series_container(value::Area) = value.time_series_container
 """Get [`Area`](@ref) `internal`."""
 get_internal(value::Area) = value.internal
 
-"""Set [`Area`](@ref) `name`."""
-set_name!(value::Area, val) = value.name = val
 """Set [`Area`](@ref) `peak_active_power`."""
 set_peak_active_power!(value::Area, val) = value.peak_active_power = set_value(value, val)
 """Set [`Area`](@ref) `peak_reactive_power`."""

--- a/src/models/generated/BatteryEMS.jl
+++ b/src/models/generated/BatteryEMS.jl
@@ -161,8 +161,6 @@ get_time_series_container(value::BatteryEMS) = value.time_series_container
 """Get [`BatteryEMS`](@ref) `internal`."""
 get_internal(value::BatteryEMS) = value.internal
 
-"""Set [`BatteryEMS`](@ref) `name`."""
-set_name!(value::BatteryEMS, val) = value.name = val
 """Set [`BatteryEMS`](@ref) `available`."""
 set_available!(value::BatteryEMS, val) = value.available = val
 """Set [`BatteryEMS`](@ref) `bus`."""

--- a/src/models/generated/Bus.jl
+++ b/src/models/generated/Bus.jl
@@ -121,8 +121,6 @@ get_internal(value::Bus) = value.internal
 
 """Set [`Bus`](@ref) `number`."""
 set_number!(value::Bus, val) = value.number = val
-"""Set [`Bus`](@ref) `name`."""
-set_name!(value::Bus, val) = value.name = val
 """Set [`Bus`](@ref) `bustype`."""
 set_bustype!(value::Bus, val) = value.bustype = val
 """Set [`Bus`](@ref) `angle`."""

--- a/src/models/generated/FixedAdmittance.jl
+++ b/src/models/generated/FixedAdmittance.jl
@@ -78,8 +78,6 @@ get_time_series_container(value::FixedAdmittance) = value.time_series_container
 """Get [`FixedAdmittance`](@ref) `internal`."""
 get_internal(value::FixedAdmittance) = value.internal
 
-"""Set [`FixedAdmittance`](@ref) `name`."""
-set_name!(value::FixedAdmittance, val) = value.name = val
 """Set [`FixedAdmittance`](@ref) `available`."""
 set_available!(value::FixedAdmittance, val) = value.available = val
 """Set [`FixedAdmittance`](@ref) `bus`."""

--- a/src/models/generated/GenericBattery.jl
+++ b/src/models/generated/GenericBattery.jl
@@ -154,8 +154,6 @@ get_time_series_container(value::GenericBattery) = value.time_series_container
 """Get [`GenericBattery`](@ref) `internal`."""
 get_internal(value::GenericBattery) = value.internal
 
-"""Set [`GenericBattery`](@ref) `name`."""
-set_name!(value::GenericBattery, val) = value.name = val
 """Set [`GenericBattery`](@ref) `available`."""
 set_available!(value::GenericBattery, val) = value.available = val
 """Set [`GenericBattery`](@ref) `bus`."""

--- a/src/models/generated/HVDCLine.jl
+++ b/src/models/generated/HVDCLine.jl
@@ -107,8 +107,6 @@ get_time_series_container(value::HVDCLine) = value.time_series_container
 """Get [`HVDCLine`](@ref) `internal`."""
 get_internal(value::HVDCLine) = value.internal
 
-"""Set [`HVDCLine`](@ref) `name`."""
-set_name!(value::HVDCLine, val) = value.name = val
 """Set [`HVDCLine`](@ref) `available`."""
 set_available!(value::HVDCLine, val) = value.available = val
 """Set [`HVDCLine`](@ref) `active_power_flow`."""

--- a/src/models/generated/HydroDispatch.jl
+++ b/src/models/generated/HydroDispatch.jl
@@ -144,8 +144,6 @@ get_time_series_container(value::HydroDispatch) = value.time_series_container
 """Get [`HydroDispatch`](@ref) `internal`."""
 get_internal(value::HydroDispatch) = value.internal
 
-"""Set [`HydroDispatch`](@ref) `name`."""
-set_name!(value::HydroDispatch, val) = value.name = val
 """Set [`HydroDispatch`](@ref) `available`."""
 set_available!(value::HydroDispatch, val) = value.available = val
 """Set [`HydroDispatch`](@ref) `bus`."""

--- a/src/models/generated/HydroEnergyReservoir.jl
+++ b/src/models/generated/HydroEnergyReservoir.jl
@@ -185,8 +185,6 @@ get_time_series_container(value::HydroEnergyReservoir) = value.time_series_conta
 """Get [`HydroEnergyReservoir`](@ref) `internal`."""
 get_internal(value::HydroEnergyReservoir) = value.internal
 
-"""Set [`HydroEnergyReservoir`](@ref) `name`."""
-set_name!(value::HydroEnergyReservoir, val) = value.name = val
 """Set [`HydroEnergyReservoir`](@ref) `available`."""
 set_available!(value::HydroEnergyReservoir, val) = value.available = val
 """Set [`HydroEnergyReservoir`](@ref) `bus`."""

--- a/src/models/generated/HydroPumpedStorage.jl
+++ b/src/models/generated/HydroPumpedStorage.jl
@@ -232,8 +232,6 @@ get_time_series_container(value::HydroPumpedStorage) = value.time_series_contain
 """Get [`HydroPumpedStorage`](@ref) `internal`."""
 get_internal(value::HydroPumpedStorage) = value.internal
 
-"""Set [`HydroPumpedStorage`](@ref) `name`."""
-set_name!(value::HydroPumpedStorage, val) = value.name = val
 """Set [`HydroPumpedStorage`](@ref) `available`."""
 set_available!(value::HydroPumpedStorage, val) = value.available = val
 """Set [`HydroPumpedStorage`](@ref) `bus`."""

--- a/src/models/generated/InterruptibleLoad.jl
+++ b/src/models/generated/InterruptibleLoad.jl
@@ -122,8 +122,6 @@ get_time_series_container(value::InterruptibleLoad) = value.time_series_containe
 """Get [`InterruptibleLoad`](@ref) `internal`."""
 get_internal(value::InterruptibleLoad) = value.internal
 
-"""Set [`InterruptibleLoad`](@ref) `name`."""
-set_name!(value::InterruptibleLoad, val) = value.name = val
 """Set [`InterruptibleLoad`](@ref) `available`."""
 set_available!(value::InterruptibleLoad, val) = value.available = val
 """Set [`InterruptibleLoad`](@ref) `bus`."""

--- a/src/models/generated/Line.jl
+++ b/src/models/generated/Line.jl
@@ -116,8 +116,6 @@ get_time_series_container(value::Line) = value.time_series_container
 """Get [`Line`](@ref) `internal`."""
 get_internal(value::Line) = value.internal
 
-"""Set [`Line`](@ref) `name`."""
-set_name!(value::Line, val) = value.name = val
 """Set [`Line`](@ref) `available`."""
 set_available!(value::Line, val) = value.available = val
 """Set [`Line`](@ref) `active_power_flow`."""

--- a/src/models/generated/LoadZone.jl
+++ b/src/models/generated/LoadZone.jl
@@ -58,8 +58,6 @@ get_time_series_container(value::LoadZone) = value.time_series_container
 """Get [`LoadZone`](@ref) `internal`."""
 get_internal(value::LoadZone) = value.internal
 
-"""Set [`LoadZone`](@ref) `name`."""
-set_name!(value::LoadZone, val) = value.name = val
 """Set [`LoadZone`](@ref) `peak_active_power`."""
 set_peak_active_power!(value::LoadZone, val) = value.peak_active_power = set_value(value, val)
 """Set [`LoadZone`](@ref) `peak_reactive_power`."""

--- a/src/models/generated/MonitoredLine.jl
+++ b/src/models/generated/MonitoredLine.jl
@@ -124,8 +124,6 @@ get_time_series_container(value::MonitoredLine) = value.time_series_container
 """Get [`MonitoredLine`](@ref) `internal`."""
 get_internal(value::MonitoredLine) = value.internal
 
-"""Set [`MonitoredLine`](@ref) `name`."""
-set_name!(value::MonitoredLine, val) = value.name = val
 """Set [`MonitoredLine`](@ref) `available`."""
 set_available!(value::MonitoredLine, val) = value.available = val
 """Set [`MonitoredLine`](@ref) `active_power_flow`."""

--- a/src/models/generated/PeriodicVariableSource.jl
+++ b/src/models/generated/PeriodicVariableSource.jl
@@ -119,8 +119,6 @@ get_ext(value::PeriodicVariableSource) = value.ext
 """Get [`PeriodicVariableSource`](@ref) `internal`."""
 get_internal(value::PeriodicVariableSource) = value.internal
 
-"""Set [`PeriodicVariableSource`](@ref) `name`."""
-set_name!(value::PeriodicVariableSource, val) = value.name = val
 """Set [`PeriodicVariableSource`](@ref) `R_th`."""
 set_R_th!(value::PeriodicVariableSource, val) = value.R_th = val
 """Set [`PeriodicVariableSource`](@ref) `X_th`."""

--- a/src/models/generated/PhaseShiftingTransformer.jl
+++ b/src/models/generated/PhaseShiftingTransformer.jl
@@ -121,8 +121,6 @@ get_time_series_container(value::PhaseShiftingTransformer) = value.time_series_c
 """Get [`PhaseShiftingTransformer`](@ref) `internal`."""
 get_internal(value::PhaseShiftingTransformer) = value.internal
 
-"""Set [`PhaseShiftingTransformer`](@ref) `name`."""
-set_name!(value::PhaseShiftingTransformer, val) = value.name = val
 """Set [`PhaseShiftingTransformer`](@ref) `available`."""
 set_available!(value::PhaseShiftingTransformer, val) = value.available = val
 """Set [`PhaseShiftingTransformer`](@ref) `active_power_flow`."""

--- a/src/models/generated/PowerLoad.jl
+++ b/src/models/generated/PowerLoad.jl
@@ -115,8 +115,6 @@ get_time_series_container(value::PowerLoad) = value.time_series_container
 """Get [`PowerLoad`](@ref) `internal`."""
 get_internal(value::PowerLoad) = value.internal
 
-"""Set [`PowerLoad`](@ref) `name`."""
-set_name!(value::PowerLoad, val) = value.name = val
 """Set [`PowerLoad`](@ref) `available`."""
 set_available!(value::PowerLoad, val) = value.available = val
 """Set [`PowerLoad`](@ref) `bus`."""

--- a/src/models/generated/RenewableDispatch.jl
+++ b/src/models/generated/RenewableDispatch.jl
@@ -130,8 +130,6 @@ get_time_series_container(value::RenewableDispatch) = value.time_series_containe
 """Get [`RenewableDispatch`](@ref) `internal`."""
 get_internal(value::RenewableDispatch) = value.internal
 
-"""Set [`RenewableDispatch`](@ref) `name`."""
-set_name!(value::RenewableDispatch, val) = value.name = val
 """Set [`RenewableDispatch`](@ref) `available`."""
 set_available!(value::RenewableDispatch, val) = value.available = val
 """Set [`RenewableDispatch`](@ref) `bus`."""

--- a/src/models/generated/RenewableFix.jl
+++ b/src/models/generated/RenewableFix.jl
@@ -117,8 +117,6 @@ get_time_series_container(value::RenewableFix) = value.time_series_container
 """Get [`RenewableFix`](@ref) `internal`."""
 get_internal(value::RenewableFix) = value.internal
 
-"""Set [`RenewableFix`](@ref) `name`."""
-set_name!(value::RenewableFix, val) = value.name = val
 """Set [`RenewableFix`](@ref) `available`."""
 set_available!(value::RenewableFix, val) = value.available = val
 """Set [`RenewableFix`](@ref) `bus`."""

--- a/src/models/generated/ReserveDemandCurve.jl
+++ b/src/models/generated/ReserveDemandCurve.jl
@@ -74,8 +74,6 @@ get_internal(value::ReserveDemandCurve) = value.internal
 
 """Set [`ReserveDemandCurve`](@ref) `variable`."""
 set_variable!(value::ReserveDemandCurve, val) = value.variable = val
-"""Set [`ReserveDemandCurve`](@ref) `name`."""
-set_name!(value::ReserveDemandCurve, val) = value.name = val
 """Set [`ReserveDemandCurve`](@ref) `available`."""
 set_available!(value::ReserveDemandCurve, val) = value.available = val
 """Set [`ReserveDemandCurve`](@ref) `time_frame`."""

--- a/src/models/generated/Source.jl
+++ b/src/models/generated/Source.jl
@@ -111,8 +111,6 @@ get_ext(value::Source) = value.ext
 """Get [`Source`](@ref) `internal`."""
 get_internal(value::Source) = value.internal
 
-"""Set [`Source`](@ref) `name`."""
-set_name!(value::Source, val) = value.name = val
 """Set [`Source`](@ref) `available`."""
 set_available!(value::Source, val) = value.available = val
 """Set [`Source`](@ref) `bus`."""

--- a/src/models/generated/StaticReserve.jl
+++ b/src/models/generated/StaticReserve.jl
@@ -65,8 +65,6 @@ get_ext(value::StaticReserve) = value.ext
 """Get [`StaticReserve`](@ref) `internal`."""
 get_internal(value::StaticReserve) = value.internal
 
-"""Set [`StaticReserve`](@ref) `name`."""
-set_name!(value::StaticReserve, val) = value.name = val
 """Set [`StaticReserve`](@ref) `available`."""
 set_available!(value::StaticReserve, val) = value.available = val
 """Set [`StaticReserve`](@ref) `time_frame`."""

--- a/src/models/generated/StaticReserveGroup.jl
+++ b/src/models/generated/StaticReserveGroup.jl
@@ -65,8 +65,6 @@ get_contributing_services(value::StaticReserveGroup) = value.contributing_servic
 """Get [`StaticReserveGroup`](@ref) `internal`."""
 get_internal(value::StaticReserveGroup) = value.internal
 
-"""Set [`StaticReserveGroup`](@ref) `name`."""
-set_name!(value::StaticReserveGroup, val) = value.name = val
 """Set [`StaticReserveGroup`](@ref) `available`."""
 set_available!(value::StaticReserveGroup, val) = value.available = val
 """Set [`StaticReserveGroup`](@ref) `requirement`."""

--- a/src/models/generated/StaticReserveNonSpinning.jl
+++ b/src/models/generated/StaticReserveNonSpinning.jl
@@ -65,8 +65,6 @@ get_ext(value::StaticReserveNonSpinning) = value.ext
 """Get [`StaticReserveNonSpinning`](@ref) `internal`."""
 get_internal(value::StaticReserveNonSpinning) = value.internal
 
-"""Set [`StaticReserveNonSpinning`](@ref) `name`."""
-set_name!(value::StaticReserveNonSpinning, val) = value.name = val
 """Set [`StaticReserveNonSpinning`](@ref) `available`."""
 set_available!(value::StaticReserveNonSpinning, val) = value.available = val
 """Set [`StaticReserveNonSpinning`](@ref) `time_frame`."""

--- a/src/models/generated/TapTransformer.jl
+++ b/src/models/generated/TapTransformer.jl
@@ -116,8 +116,6 @@ get_time_series_container(value::TapTransformer) = value.time_series_container
 """Get [`TapTransformer`](@ref) `internal`."""
 get_internal(value::TapTransformer) = value.internal
 
-"""Set [`TapTransformer`](@ref) `name`."""
-set_name!(value::TapTransformer, val) = value.name = val
 """Set [`TapTransformer`](@ref) `available`."""
 set_available!(value::TapTransformer, val) = value.available = val
 """Set [`TapTransformer`](@ref) `active_power_flow`."""

--- a/src/models/generated/ThermalMultiStart.jl
+++ b/src/models/generated/ThermalMultiStart.jl
@@ -188,8 +188,6 @@ get_time_series_container(value::ThermalMultiStart) = value.time_series_containe
 """Get [`ThermalMultiStart`](@ref) `internal`."""
 get_internal(value::ThermalMultiStart) = value.internal
 
-"""Set [`ThermalMultiStart`](@ref) `name`."""
-set_name!(value::ThermalMultiStart, val) = value.name = val
 """Set [`ThermalMultiStart`](@ref) `available`."""
 set_available!(value::ThermalMultiStart, val) = value.available = val
 """Set [`ThermalMultiStart`](@ref) `status`."""

--- a/src/models/generated/ThermalStandard.jl
+++ b/src/models/generated/ThermalStandard.jl
@@ -162,8 +162,6 @@ get_time_series_container(value::ThermalStandard) = value.time_series_container
 """Get [`ThermalStandard`](@ref) `internal`."""
 get_internal(value::ThermalStandard) = value.internal
 
-"""Set [`ThermalStandard`](@ref) `name`."""
-set_name!(value::ThermalStandard, val) = value.name = val
 """Set [`ThermalStandard`](@ref) `available`."""
 set_available!(value::ThermalStandard, val) = value.available = val
 """Set [`ThermalStandard`](@ref) `status`."""

--- a/src/models/generated/Transfer.jl
+++ b/src/models/generated/Transfer.jl
@@ -64,8 +64,6 @@ get_time_series_container(value::Transfer) = value.time_series_container
 """Get [`Transfer`](@ref) `internal`."""
 get_internal(value::Transfer) = value.internal
 
-"""Set [`Transfer`](@ref) `name`."""
-set_name!(value::Transfer, val) = value.name = val
 """Set [`Transfer`](@ref) `available`."""
 set_available!(value::Transfer, val) = value.available = val
 """Set [`Transfer`](@ref) `requirement`."""

--- a/src/models/generated/Transformer2W.jl
+++ b/src/models/generated/Transformer2W.jl
@@ -110,8 +110,6 @@ get_time_series_container(value::Transformer2W) = value.time_series_container
 """Get [`Transformer2W`](@ref) `internal`."""
 get_internal(value::Transformer2W) = value.internal
 
-"""Set [`Transformer2W`](@ref) `name`."""
-set_name!(value::Transformer2W, val) = value.name = val
 """Set [`Transformer2W`](@ref) `available`."""
 set_available!(value::Transformer2W, val) = value.available = val
 """Set [`Transformer2W`](@ref) `active_power_flow`."""

--- a/src/models/generated/VSCDCLine.jl
+++ b/src/models/generated/VSCDCLine.jl
@@ -113,8 +113,6 @@ get_time_series_container(value::VSCDCLine) = value.time_series_container
 """Get [`VSCDCLine`](@ref) `internal`."""
 get_internal(value::VSCDCLine) = value.internal
 
-"""Set [`VSCDCLine`](@ref) `name`."""
-set_name!(value::VSCDCLine, val) = value.name = val
 """Set [`VSCDCLine`](@ref) `available`."""
 set_available!(value::VSCDCLine, val) = value.available = val
 """Set [`VSCDCLine`](@ref) `active_power_flow`."""

--- a/src/models/generated/VariableReserve.jl
+++ b/src/models/generated/VariableReserve.jl
@@ -72,8 +72,6 @@ get_time_series_container(value::VariableReserve) = value.time_series_container
 """Get [`VariableReserve`](@ref) `internal`."""
 get_internal(value::VariableReserve) = value.internal
 
-"""Set [`VariableReserve`](@ref) `name`."""
-set_name!(value::VariableReserve, val) = value.name = val
 """Set [`VariableReserve`](@ref) `available`."""
 set_available!(value::VariableReserve, val) = value.available = val
 """Set [`VariableReserve`](@ref) `time_frame`."""

--- a/src/models/generated/VariableReserveNonSpinning.jl
+++ b/src/models/generated/VariableReserveNonSpinning.jl
@@ -72,8 +72,6 @@ get_time_series_container(value::VariableReserveNonSpinning) = value.time_series
 """Get [`VariableReserveNonSpinning`](@ref) `internal`."""
 get_internal(value::VariableReserveNonSpinning) = value.internal
 
-"""Set [`VariableReserveNonSpinning`](@ref) `name`."""
-set_name!(value::VariableReserveNonSpinning, val) = value.name = val
 """Set [`VariableReserveNonSpinning`](@ref) `available`."""
 set_available!(value::VariableReserveNonSpinning, val) = value.available = val
 """Set [`VariableReserveNonSpinning`](@ref) `time_frame`."""

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -246,6 +246,11 @@ end
     add_component!(sys, bus)
     set_name!(sys, bus, "new_name")
     @test get_component(Bus, sys, "new_name") === bus
+
+    @test_throws ErrorException set_name!(bus, "new_name2")
+    remove_component!(sys, bus)
+    set_name!(bus, "new_name2")
+    @test get_name(bus) == "new_name2"
 end
 
 @testset "Test forecast parameters" begin


### PR DESCRIPTION
CI will fail until https://github.com/NREL-SIIP/InfrastructureSystems.jl/pull/268 is merged and tagged.

The purpose of this PR is block users from changing the name of a component that is attached to a system with `set_name!(component, name)`.
