### PR TITLE
Fix serialization of Union types with Nothing

### DIFF
--- a/src/models/HybridSystem.jl
+++ b/src/models/HybridSystem.jl
@@ -24,7 +24,7 @@ mutable struct HybridSystem <: StaticInjectionSubsystem
     renewable_unit::Union{Nothing, RenewableGen}
     # interconnection Data
     "Thermal limited MVA Power Output of the unit. <= Capacity"
-    interconnection_impedance::Union{Nothing, ComplexF64}
+    interconnection_impedance::ComplexF64
     interconnection_rating::Union{Nothing, Float64}
     input_active_power_limits::Union{Nothing, Min_Max}
     output_active_power_limits::Union{Nothing, Min_Max}
@@ -52,7 +52,7 @@ function HybridSystem(;
     electric_load = nothing,
     storage = nothing,
     renewable_unit = nothing,
-    interconnection_impedance = nothing,
+    interconnection_impedance = 0.0,
     interconnection_rating = nothing,
     input_active_power_limits = nothing,
     output_active_power_limits = nothing,
@@ -104,7 +104,7 @@ function HybridSystem(::Nothing)
         electric_load = PowerLoad(nothing),
         storage = GenericBattery(nothing),
         renewable_unit = RenewableDispatch(nothing),
-        interconnection_impedance = nothing,
+        interconnection_impedance = 0.0,
         interconnection_rating = nothing,
         input_active_power_limits = nothing,
         output_active_power_limits = nothing,

--- a/src/models/serialization.jl
+++ b/src/models/serialization.jl
@@ -101,7 +101,9 @@ function deserialize_uuid_handling(field_type, val, component_cache)
         value = IS.deserialize(field_type.b, val, component_cache)
     elseif field_type <: InfrastructureSystemsType
         value = deserialize(field_type, val)
-    elseif field_type <: Union{Nothing, InfrastructureSystemsType}
+    elseif field_type isa Union && field_type.a <: Nothing && !(field_type.b <: Union)
+        # Nothing has already been handled. Apply the second type as long as there isn't a
+        # third. Julia appears to always put the Nothing in field a.
         value = deserialize(field_type.b, val)
     else
         value = deserialize(field_type, val)


### PR DESCRIPTION
This fixes a bug when deserializing a HybridSystem that has a interconnection_impedance with a complex number instead of nothing.
