### PR TITLE
Add subcomponent time series to subsystem

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -233,6 +233,7 @@ export remove_time_series!
 export check_time_series_consistency
 export clear_time_series!
 export copy_time_series!
+export copy_subcomponent_time_series!
 export add_component!
 export add_components!
 export remove_component!

--- a/src/base.jl
+++ b/src/base.jl
@@ -1689,6 +1689,7 @@ function handle_component_addition!(
     for subcomponent in get_subcomponents(subsystem)
         if is_attached(subcomponent, sys)
             IS.mask_component!(sys.data, subcomponent)
+            copy_subcomponent_time_series!(subsystem, subcomponent)
         else
             IS.add_masked_component!(sys.data, subcomponent)
         end

--- a/src/models/static_injection_subsystem.jl
+++ b/src/models/static_injection_subsystem.jl
@@ -7,3 +7,34 @@ Subtypes must implement:
 The subcomponents in subtypes must be attached to the System as masked components.
 """
 abstract type StaticInjectionSubsystem <: StaticInjection end
+
+"""
+Efficiently add all time series data in the subcomponent to the subsystem by copying the
+underlying references.
+"""
+function copy_subcomponent_time_series!(
+    subsystem::StaticInjectionSubsystem,
+    subcomponent::Component,
+)
+    existing_ts = Set((typeof(x), get_name(x)) for x in get_time_series_multiple(subsystem))
+    name_mapping = Dict{String, String}()
+    for ts in get_time_series_multiple(subcomponent)
+        name = get_name(ts)
+        key = (typeof(ts), name)
+        if !(key in existing_ts)
+            new_name = make_subsystem_time_series_name(subcomponent, ts)
+            if name in keys(name_mapping)
+                IS.@assert_op new_name == name_mapping[name]
+                continue
+            end
+            name_mapping[name] = new_name
+        end
+    end
+
+    copy_time_series!(subsystem, subcomponent, name_mapping = name_mapping)
+    @info "Copied time series from $(summary(subcomponent)) to $(summary(subsystem))"
+end
+
+function make_subsystem_time_series_name(subcomponent::Component, ts::TimeSeriesData)
+    return IS.strip_module_name(typeof(subcomponent)) * "__" * get_name(ts)
+end


### PR DESCRIPTION
The purpose of this PR is to make HybridSystem subcomponent time series available at the HybridSystem for use in PowerSimulations. If you add a HybridSystem with subcomponents already attached to the System then the HybridSystem will have references to the their time series in the format `<typeof(subcomponent)>__<time_series_name>`.

There is one possible problem with this solution. If the user adds time series data to a subcomponent _after_ adding the HybridSystem to the System then it is up to that user to call `copy_subcomponent_time_series!`. Is this a deal breaker?
