### PR TITLE
Add get_components method with filter_func

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -822,14 +822,26 @@ Call collect on the result if an array is desired.
 ```julia
 iter = PowerSystems.get_components(ThermalStandard, sys)
 iter = PowerSystems.get_components(Generator, sys)
-iter = PowerSystems.get_components(Generator, sys, x->(PowerSystems.get_available(x)))
+iter = PowerSystems.get_components(Generator, sys, x -> PowerSystems.get_available(x))
+thermal_gens = get_components(ThermalStandard, sys) do gen
+    get_available(gen)
+end
 generators = collect(PowerSystems.get_components(Generator, sys))
+
 ```
 
 See also: [`iterate_components`](@ref)
 """
 function get_components(::Type{T}, sys::System) where {T <: Component}
     return IS.get_components(T, sys.data, nothing)
+end
+
+function get_components(
+    filter_func::Function,
+    ::Type{T},
+    sys::System,
+) where {T <: Component}
+    return IS.get_components(T, sys.data, filter_func)
 end
 
 # These two methods are defined independently instead of  filter_func::Union{Function, Nothing} = nothing

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -1,4 +1,3 @@
-
 @testset "Test functionality of System" begin
     sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys"; add_forecasts = false)
     summary(devnull, sys)
@@ -84,6 +83,17 @@
     clear_time_series!(sys)
     @test length(collect(get_time_series_multiple(sys))) == 0
     @test IS.get_internal(sys) isa IS.InfrastructureSystemsInternal
+end
+
+@testset "Test get_componets filter_func" begin
+    sys = PSB.build_system(PSITestSystems, "test_RTS_GMLC_sys"; add_forecasts = false)
+    gen = first(get_components(ThermalStandard, sys))
+    name = get_name(gen)
+    generators = get_components(ThermalStandard, sys) do gen
+        get_name(gen) == name && get_available(gen)
+    end
+
+    @test length(generators) == 1 && get_name(first(generators)) == name
 end
 
 @testset "Test handling of bus_numbers" begin


### PR DESCRIPTION
This follows the Julia parameter-order convention where a function is listed first so that do blocks can be used for the function.

The existing implementation is unchanged, so users can choose their preferred way of using the feature.