### PR TITLE
Fix Source R and X source base values

### DIFF
--- a/src/parsers/psse_dynamic_data.jl
+++ b/src/parsers/psse_dynamic_data.jl
@@ -113,15 +113,19 @@ function _make_shaft(param_map, val)
     return constructor_shaft(shaft_args...)
 end
 
-function _make_source(g::StaticInjection, r::Float64, x::Float64)
+function _make_source(g::StaticInjection, r::Float64, x::Float64, sys_base::Float64)
+    # Transform Z_source to System Base
+    machine_base = get_base_power(g)
+    r_sysbase = r * (sys_base / machine_base)
+    x_sysbase = x * (sys_base / machine_base)
     return Source(
         name = get_name(g),
         available = true,
         bus = get_bus(g),
         active_power = get_active_power(g),
         reactive_power = get_reactive_power(g),
-        R_th = r,
-        X_th = x,
+        R_th = r_sysbase,
+        X_th = x_sysbase,
     )
 end
 
@@ -463,7 +467,7 @@ function add_dyn_injectors!(sys::System, bus_dict_gen::Dict)
                     set_Xd_p!(machine, x)
                     if get_H(shaft) == 0.0
                         @info "Machine at bus $(_num), id $(_id) has zero inertia. Modeling it as Voltage Source"
-                        s = _make_source(g, r, x)
+                        s = _make_source(g, r, x, get_base_power(sys))
                         remove_component!(typeof(g), sys, _name)
                         add_component!(sys, s)
                         # Don't add DynamicComponent in case of adding Source

--- a/src/parsers/psse_dynamic_data.jl
+++ b/src/parsers/psse_dynamic_data.jl
@@ -447,7 +447,7 @@ function add_dyn_injectors!(sys::System, bus_dict_gen::Dict)
                 @warn "No series reactance found. Setting it to 1e-6"
                 x = 1e-6
             end
-            s = _make_source(g, r, x)
+            s = _make_source(g, r, x, get_base_power(sys))
             remove_component!(typeof(g), sys, _name)
             add_component!(sys, s)
         elseif all(.!ismissing.(temp_dict[_id]))


### PR DESCRIPTION
The PR fix a bug to properly set-up the R_th and X_th of a Source Model in a system base instead of a Machine base.