### PR TITLE
Improve printing of time series instances

### DIFF
--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -199,8 +199,13 @@ function Base.show(io::IO, ::MIME"text/plain", ist::Component)
                 print(io, "\n   ")
                 show(io, MIME"text/plain"(), obj.units_info)
                 continue
-            elseif obj isa IS.TimeSeriesContainer ||
-                   obj isa InfrastructureSystemsType ||
+            elseif obj isa IS.TimeSeriesContainer
+                val = ""
+                for (key, metadata) in obj.data
+                    ts_type = IS.time_series_metadata_to_data(metadata)
+                    val *= "\n      $(key.name): $ts_type"
+                end
+            elseif obj isa InfrastructureSystemsType ||
                    obj isa Vector{<:InfrastructureSystemsComponent}
                 val = summary(getproperty(ist, name))
             elseif hasproperty(PowerSystems, getter_name)
@@ -208,10 +213,6 @@ function Base.show(io::IO, ::MIME"text/plain", ist::Component)
                 val = getter_func(ist)
             else
                 val = getproperty(ist, name)
-            end
-            # Not allowed to print `nothing`
-            if isnothing(val)
-                val = "nothing"
             end
             print(io, "\n   ", name, ": ", val)
         end


### PR DESCRIPTION
Fixes #971.

@rodrigomha Here is how this shows up. We could print other fields, reverse the order of these two fields. Let me know what you'd like.
```
215_HYDRO_3 (HydroEnergyReservoir):
   name: 215_HYDRO_3
   available: true
   bus: Barton (Bus)
   active_power: 0.5
   reactive_power: 0.16
   rating: 0.5249761899362675
   prime_mover: PrimeMovers.HY = 16
   active_power_limits: (min = 0.0, max = 0.5)
   reactive_power_limits: (min = -0.1, max = 0.16)
   ramp_limits: (up = 0.5, down = 0.5)
   time_limits: (up = 0.0, down = 0.0)
   base_power: 100.0
   storage_capacity: 20.0
   inflow: 4.0
   initial_storage: 10.0
   operation_cost: TwoPartCost
   storage_target: 1.0
   conversion_factor: 1.0
   time_at_status: 10000.0
   services: 0-element Vector{Service}
   dynamic_injector: nothing
   ext: Dict{String, Any}()
   time_series_container:
      max_active_power: SingleTimeSeries
      storage_capacity: SingleTimeSeries
      inflow: SingleTimeSeries
```