### PR TITLE
Fix ThermalStandard must_run in tabular data parser

### DIFF
--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -1082,9 +1082,6 @@ function make_thermal_generator_multistart(
 
     op_cost = MultiStartCost(var_cost, no_load_cost, fixed, startup_cost, shutdown_cost)
 
-    gen_must_run = isnothing(gen.must_run) ? false : gen.must_run
-    gen_must_run = isa(gen_must_run,Bool) ? gen_must_run : parse(Bool,lowercase(String(gen_must_run)))
-
     return ThermalMultiStart(;
         name = get_name(thermal_gen),
         available = get_available(thermal_gen),
@@ -1105,7 +1102,7 @@ function make_thermal_generator_multistart(
         operation_cost = op_cost,
         base_power = get_base_power(thermal_gen),
         time_at_status = get_time_at_status(thermal_gen),
-        must_run = gen_must_run,
+        must_run = get_must_run(thermal_gen),
     )
 end
 

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -1005,10 +1005,8 @@ function make_thermal_generator(data::PowerSystemTableData, gen, cost_colnames, 
     op_cost = ThreePartCost(var_cost, fixed, startup_cost, shutdown_cost)
 
     gen_must_run = isnothing(gen.must_run) ? false : gen.must_run
-    gen_must_run = if isa(gen_must_run, Bool)
-        gen_must_run
-    else
-        parse(Bool, lowercase(String(gen_must_run)))
+    if !isa(gen_must_run, Bool)
+        gen_must_run = parse(Bool, lowercase(String(gen_must_run)))
     end
 
     return ThermalStandard(;

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -1003,8 +1003,10 @@ function make_thermal_generator(data::PowerSystemTableData, gen, cost_colnames, 
         calculate_variable_cost(data, gen, cost_colnames, base_power)
     startup_cost, shutdown_cost = calculate_uc_cost(data, gen, fuel_cost)
     op_cost = ThreePartCost(var_cost, fixed, startup_cost, shutdown_cost)
+    
     gen_must_run = isnothing(gen.must_run) ? false : gen.must_run
-
+    gen_must_run = isa(gen_must_run,Bool) ? gen_must_run : parse(Bool,lowercase(String(gen_must_run)))
+   
     return ThermalStandard(;
         name = gen.name,
         available = gen.available,
@@ -1080,6 +1082,9 @@ function make_thermal_generator_multistart(
 
     op_cost = MultiStartCost(var_cost, no_load_cost, fixed, startup_cost, shutdown_cost)
 
+    gen_must_run = isnothing(gen.must_run) ? false : gen.must_run
+    gen_must_run = isa(gen_must_run,Bool) ? gen_must_run : parse(Bool,lowercase(String(gen_must_run)))
+
     return ThermalMultiStart(;
         name = get_name(thermal_gen),
         available = get_available(thermal_gen),
@@ -1100,7 +1105,7 @@ function make_thermal_generator_multistart(
         operation_cost = op_cost,
         base_power = get_base_power(thermal_gen),
         time_at_status = get_time_at_status(thermal_gen),
-        must_run = gen.must_run,
+        must_run = gen_must_run,
     )
 end
 

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -1020,6 +1020,7 @@ function make_thermal_generator(data::PowerSystemTableData, gen, cost_colnames, 
         time_limits = timelimits,
         operation_cost = op_cost,
         base_power = base_power,
+        must_run = gen.must_run,
     )
 end
 

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -1003,10 +1003,14 @@ function make_thermal_generator(data::PowerSystemTableData, gen, cost_colnames, 
         calculate_variable_cost(data, gen, cost_colnames, base_power)
     startup_cost, shutdown_cost = calculate_uc_cost(data, gen, fuel_cost)
     op_cost = ThreePartCost(var_cost, fixed, startup_cost, shutdown_cost)
-    
+
     gen_must_run = isnothing(gen.must_run) ? false : gen.must_run
-    gen_must_run = isa(gen_must_run,Bool) ? gen_must_run : parse(Bool,lowercase(String(gen_must_run)))
-   
+    gen_must_run = if isa(gen_must_run, Bool)
+        gen_must_run
+    else
+        parse(Bool, lowercase(String(gen_must_run)))
+    end
+
     return ThermalStandard(;
         name = gen.name,
         available = gen.available,

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -1003,6 +1003,7 @@ function make_thermal_generator(data::PowerSystemTableData, gen, cost_colnames, 
         calculate_variable_cost(data, gen, cost_colnames, base_power)
     startup_cost, shutdown_cost = calculate_uc_cost(data, gen, fuel_cost)
     op_cost = ThreePartCost(var_cost, fixed, startup_cost, shutdown_cost)
+    gen_must_run = isnothing(gen.must_run) ? false : gen.must_run
 
     return ThermalStandard(;
         name = gen.name,
@@ -1020,7 +1021,7 @@ function make_thermal_generator(data::PowerSystemTableData, gen, cost_colnames, 
         time_limits = timelimits,
         operation_cost = op_cost,
         base_power = base_power,
-        must_run = gen.must_run,
+        must_run = gen_must_run,
     )
 end
 


### PR DESCRIPTION
Thanks for opening a PR to PowerSystems.jl, please take note of the following when making a PR: 

Check the [contributor guidelines](https://nrel-siip.github.io/PowerSystems.jl/stable/code_base_developer_guide/developer/)

1. Fix tabular data parser to parse _must_run_  for **ThermalStandard**
2. [Issue Fix](https://github.com/NREL-SIIP/PowerSystems.jl/issues/981)

closes #981 
