### PR TITLE
Mb/fixes for ybus tests

### DIFF
--- a/src/models/supplemental_accessors.jl
+++ b/src/models/supplemental_accessors.jl
@@ -141,3 +141,28 @@ function get_phase_shift(t::Union{TapTransformer, Transformer2W})
         return get_winding_group_number(t).value * -(π / 6)
     end
 end
+
+function get_phase_shift_primary(t::Transformer3W)
+    if get_primary_group_number(t) == WindingGroupNumber.UNDEFINED
+        @warn "primary winding group number for summary (t) is undefined, assuming zero phase shift"
+        return 0.0
+    else
+        return get_primary_group_number(t).value * -(π / 6)
+    end
+end
+function get_phase_shift_secondary(t::Transformer3W)
+    if get_secondary_group_number(t) == WindingGroupNumber.UNDEFINED
+        @warn "secondary winding group number for summary (t) is undefined, assuming zero phase shift"
+        return 0.0
+    else
+        return get_secondary_group_number(t).value * -(π / 6)
+    end
+end
+function get_phase_shift_tertiary(t::Transformer3W)
+    if get_tertiary_group_number(t) == WindingGroupNumber.UNDEFINED
+        @warn "tertiary winding group number for summary (t) is undefined, assuming zero phase shift"
+        return 0.0
+    else
+        return get_tertiary_group_number(t).value * -(π / 6)
+    end
+end


### PR DESCRIPTION
Changes needed to get the PNM ybus tests to pass. 
An open question: Is it reasonable to log a warning and return a phase shift of zero if the winding group number is undefined? 