### PR TITLE
Add full time-variable `ImportExportCost` interface

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -78,7 +78,8 @@ export ProductionVariableCostCurve, CostCurve, FuelCurve
 export get_function_data, get_initial_input, get_input_at_zero
 export get_value_curve, get_power_units
 
-export OperationalCost, MarketBidCost, LoadCost, StorageCost, ImportExportCost
+export OperationalCost,
+    OfferCurveCost, MarketBidCost, LoadCost, StorageCost, ImportExportCost
 export HydroGenerationCost, RenewableGenerationCost, ThermalGenerationCost
 export HydroReservoirCost
 export get_fuel_cost, set_fuel_cost!, get_vom_cost
@@ -790,6 +791,7 @@ include("models/OuterControl.jl")
 
 # Costs
 include("models/cost_functions/operational_cost.jl")
+include("models/cost_functions/OfferCurveCost.jl")
 include("models/cost_functions/MarketBidCost.jl")
 include("models/cost_functions/ImportExportCost.jl")
 include("models/cost_functions/HydroGenerationCost.jl")

--- a/src/models/cost_function_timeseries.jl
+++ b/src/models/cost_function_timeseries.jl
@@ -1,17 +1,13 @@
-const OfferCurveCost = Union{MarketBidCost, ImportExportCost}
-
 # VALIDATORS
 function _validate_market_bid_cost(cost, context)
     (cost isa MarketBidCost) || throw(TypeError(
         StackTraces.stacktrace()[2].func, context, MarketBidCost, cost))
 end
 
-function _validate_reserve_demand_curve(cost, name)
-    !(cost isa CostCurve{PiecewiseIncrementalCurve}) && throw(
-        ArgumentError(
-            "Reserve curve of type $(typeof(cost)) on $name cannot represent an ORDC curve, use CostCurve{PiecewiseIncrementalCurve} instead",
-        ),
-    )
+function _validate_reserve_demand_curve(
+    cost::CostCurve{PiecewiseIncrementalCurve},
+    name::String,
+)
     value_curve = get_value_curve(cost)
     function_data = get_function_data(value_curve)
     x_coords = get_x_coords(function_data)
@@ -28,6 +24,14 @@ function _validate_reserve_demand_curve(cost, name)
             )
         end
     end
+end
+
+function _validate_reserve_demand_curve(cost::T, name::String) where {T <: CostCurve}
+    throw(
+        ArgumentError(
+            "Reserve curve of type $(typeof(cost)) on $name cannot represent an ORDC curve, use CostCurve{PiecewiseIncrementalCurve} instead",
+        ),
+    )
 end
 
 function _validate_fuel_curve(component::Component)

--- a/src/models/cost_functions/ImportExportCost.jl
+++ b/src/models/cost_functions/ImportExportCost.jl
@@ -8,7 +8,7 @@ $(TYPEDFIELDS)
 An operating cost for imports/exports and ancillary services from neighboring areas. The data model
 employs a CostCurve{PiecewiseIncrementalCurve} with an implied zero cost at zero power.
 """
-mutable struct ImportExportCost <: OperationalCost
+mutable struct ImportExportCost <: OfferCurveCost
     "Buy Price Curves data to import power, which can be a time series of [`PiecewiseStepData`] or a
     [`CostCurve`](@ref) of [`PiecewiseIncrementalCurve`](@ref)"
     import_offer_curves::Union{

--- a/src/models/cost_functions/MarketBidCost.jl
+++ b/src/models/cost_functions/MarketBidCost.jl
@@ -9,10 +9,10 @@ $(TYPEDFIELDS)
 An operating cost for market bids of energy and ancilliary services for any asset.
 Compatible with most US Market bidding mechanisms that support demand and generation side.
 """
-mutable struct MarketBidCost <: OperationalCost
+mutable struct MarketBidCost <: OfferCurveCost
     "No load cost"
     no_load_cost::Union{TimeSeriesKey, Nothing, Float64}
-    "Start-up cost at different stages of the thermal cycle as the unit cools after a 
+    "Start-up cost at different stages of the thermal cycle as the unit cools after a
     shutdown (e.g., *hot*, *warm*, or *cold* starts). Warm is also referred to as
     intermediate in some markets. Can also accept a single value if there is only one
     start-up cost"
@@ -256,7 +256,7 @@ function make_market_bid_curve(data::PiecewiseStepData,
 end
 
 """
-Auxiliary make market bid curve for timeseries with nothing inputs. 
+Auxiliary make market bid curve for timeseries with nothing inputs.
 """
 function _make_market_bid_curve(data::PiecewiseStepData;
     initial_input::Union{Nothing, Float64} = nothing,

--- a/src/models/cost_functions/OfferCurveCost.jl
+++ b/src/models/cost_functions/OfferCurveCost.jl
@@ -1,0 +1,13 @@
+"""
+    OfferCurveCost
+
+Abstract type for representing cost curves used in market bidding and offer mechanisms.
+
+This serves as the base type for various cost curve implementations including:
+- [`MarketBidCost`](@ref)
+- [`ImportExportCost`](@ref)
+
+All concrete subtypes must implement the required interface methods for cost calculation
+and curve evaluation in power system market operations.
+"""
+abstract type OfferCurveCost <: OperationalCost end

--- a/src/models/cost_functions/operational_cost.jl
+++ b/src/models/cost_functions/operational_cost.jl
@@ -1,14 +1,17 @@
 """
 Supertype for operational cost representations
 
+Current abstract type for representing operational costs associated with power system devices.
+- [`OfferCurveCost`](@ref)
+
 Current concrete types include:
 - [`ThermalGenerationCost`](@ref)
 - [`HydroGenerationCost`](@ref)
 - [`RenewableGenerationCost`](@ref)
 - [`StorageCost`](@ref)
 - [`LoadCost`](@ref)
-- [`MarketBidCost`](@ref)
 - [`ImportExportCost`](@ref)
+- [`MarketBidCost`](@ref)
 """
 abstract type OperationalCost <: DeviceParameter end
 


### PR DESCRIPTION
There's quite a lot of stuff in `cost_function_timeseries.jl` to support interaction with `MarketBidCost`, and I think we should implement the corresponding methods for `ImportExportCost`. So far I'm focusing on the methods that are necessary to support PowerSimulations, but we should also do the user-facing ones.